### PR TITLE
[#3] 회원 정보 조회/수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation 'org.spockframework:spock-spring:2.3-groovy-3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
+++ b/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
@@ -78,4 +78,15 @@ public class MemberController {
 			.status(SUCCESS)
 			.build());
 	}
+
+	@MemberLoginCheck
+	@PatchMapping("/withdraw")
+	public ResponseEntity<ResponseMessage> withdrawMember(HttpSession session) {
+		Long memberId = SessionUtil.getLoginMemberId(session);
+		memberService.withdrawMember(memberId);
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
+			.build());
+	}
 }

--- a/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
+++ b/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import com.flab.idolu.domain.member.dto.request.LoginMemberDto;
 import com.flab.idolu.domain.member.dto.request.ModifyMemberDto;
 import com.flab.idolu.domain.member.dto.request.SignUpMemberDto;
 import com.flab.idolu.domain.member.service.MemberService;
+import com.flab.idolu.global.annotation.MemberLoginCheck;
 import com.flab.idolu.global.common.ResponseMessage;
 import com.flab.idolu.global.util.SessionUtil;
 
@@ -54,6 +55,7 @@ public class MemberController {
 			.build());
 	}
 
+	@MemberLoginCheck
 	@GetMapping("/myInfo")
 	public ResponseEntity<ResponseMessage> findMyInfo(HttpSession session) {
 		Long memberId = SessionUtil.getLoginMemberId(session);
@@ -64,6 +66,7 @@ public class MemberController {
 			.build());
 	}
 
+	@MemberLoginCheck
 	@PatchMapping("/myInfo/edit")
 	public ResponseEntity<ResponseMessage> modifyMyInfo(HttpSession session,
 		@RequestBody ModifyMemberDto modifyMemberDto) {

--- a/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
+++ b/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
@@ -4,12 +4,14 @@ import static com.flab.idolu.global.common.ResponseMessage.Status.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.idolu.domain.member.dto.request.LoginMemberDto;
+import com.flab.idolu.domain.member.dto.request.ModifyMemberDto;
 import com.flab.idolu.domain.member.dto.request.SignUpMemberDto;
 import com.flab.idolu.domain.member.service.MemberService;
 import com.flab.idolu.global.common.ResponseMessage;
@@ -52,13 +54,25 @@ public class MemberController {
 			.build());
 	}
 
-	@GetMapping("/myinfo")
+	@GetMapping("/myInfo")
 	public ResponseEntity<ResponseMessage> findMyInfo(HttpSession session) {
 		Long memberId = SessionUtil.getLoginMemberId(session);
 
 		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)
 			.result(memberService.getMemberInfo(memberId))
+			.build());
+	}
+
+	@PatchMapping("/myInfo/edit")
+	public ResponseEntity<ResponseMessage> modifyMyInfo(HttpSession session,
+		@RequestBody ModifyMemberDto modifyMemberDto) {
+
+		Long memberId = SessionUtil.getLoginMemberId(session);
+		memberService.modifyMemberInfo(modifyMemberDto, memberId);
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
 			.build());
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
+++ b/src/main/java/com/flab/idolu/domain/member/controller/MemberController.java
@@ -13,7 +13,9 @@ import com.flab.idolu.domain.member.dto.request.LoginMemberDto;
 import com.flab.idolu.domain.member.dto.request.SignUpMemberDto;
 import com.flab.idolu.domain.member.service.MemberService;
 import com.flab.idolu.global.common.ResponseMessage;
+import com.flab.idolu.global.util.SessionUtil;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -47,6 +49,16 @@ public class MemberController {
 
 		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)
+			.build());
+	}
+
+	@GetMapping("/myinfo")
+	public ResponseEntity<ResponseMessage> findMyInfo(HttpSession session) {
+		Long memberId = SessionUtil.getLoginMemberId(session);
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
+			.result(memberService.getMemberInfo(memberId))
 			.build());
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/member/dto/request/ModifyMemberDto.java
+++ b/src/main/java/com/flab/idolu/domain/member/dto/request/ModifyMemberDto.java
@@ -1,0 +1,22 @@
+package com.flab.idolu.domain.member.dto.request;
+
+import com.flab.idolu.domain.member.entity.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ModifyMemberDto {
+
+	private String name;
+	private String phone;
+
+	public Member toEntity(Long memberId) {
+		return Member.builder()
+			.id(memberId)
+			.name(name)
+			.phone(phone)
+			.build();
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/member/dto/response/MyInfoMemberDto.java
+++ b/src/main/java/com/flab/idolu/domain/member/dto/response/MyInfoMemberDto.java
@@ -1,0 +1,23 @@
+package com.flab.idolu.domain.member.dto.response;
+
+import com.flab.idolu.domain.member.entity.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyInfoMemberDto {
+
+	private String email;
+	private String name;
+	private String phone;
+
+	public static MyInfoMemberDto from(Member member) {
+		return MyInfoMemberDto.builder()
+			.email(member.getEmail())
+			.name(member.getName())
+			.phone(member.getPhone())
+			.build();
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/member/exception/UnauthorizedMemberException.java
+++ b/src/main/java/com/flab/idolu/domain/member/exception/UnauthorizedMemberException.java
@@ -1,0 +1,8 @@
+package com.flab.idolu.domain.member.exception;
+
+public class UnauthorizedMemberException extends RuntimeException {
+
+	public UnauthorizedMemberException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/flab/idolu/domain/member/repository/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository {
 	Long insertMember(Member member);
 
 	Optional<Member> findByEmail(String email);
+
+	Optional<Member> findById(Long memberId);
 }

--- a/src/main/java/com/flab/idolu/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/flab/idolu/domain/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository {
 	Optional<Member> findByEmail(String email);
 
 	Optional<Member> findById(Long memberId);
+
+	void updateMember(Member member);
 }

--- a/src/main/java/com/flab/idolu/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/flab/idolu/domain/member/repository/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository {
 	Optional<Member> findById(Long memberId);
 
 	void updateMember(Member member);
+
+	void updateIsDeleted(Long memberId);
 }

--- a/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import org.springframework.util.Assert;
 
 import com.flab.idolu.domain.member.dto.request.LoginMemberDto;
 import com.flab.idolu.domain.member.dto.request.SignUpMemberDto;
+import com.flab.idolu.domain.member.dto.response.MyInfoMemberDto;
 import com.flab.idolu.domain.member.entity.Member;
 import com.flab.idolu.domain.member.exception.EmailDuplicateException;
 import com.flab.idolu.domain.member.exception.MemberNotFoundException;
@@ -63,6 +64,14 @@ public class MemberService {
 
 	public void logout() {
 		SessionUtil.removeLoginMemberId(httpSession);
+	}
+
+	@Transactional(readOnly = true)
+	public MyInfoMemberDto getMemberInfo(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberNotFoundException("존재하지 않는 회원입니다."));
+
+		return MyInfoMemberDto.from(member);
 	}
 
 	private void validateLoginMemberDto(LoginMemberDto loginMemberDto) {

--- a/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.flab.idolu.domain.member.dto.request.LoginMemberDto;
+import com.flab.idolu.domain.member.dto.request.ModifyMemberDto;
 import com.flab.idolu.domain.member.dto.request.SignUpMemberDto;
 import com.flab.idolu.domain.member.dto.response.MyInfoMemberDto;
 import com.flab.idolu.domain.member.entity.Member;
@@ -72,6 +73,18 @@ public class MemberService {
 			.orElseThrow(() -> new MemberNotFoundException("존재하지 않는 회원입니다."));
 
 		return MyInfoMemberDto.from(member);
+	}
+
+	@Transactional
+	public void modifyMemberInfo(ModifyMemberDto modifyMemberDto, Long memberId) {
+		validateModifyMemberDto(modifyMemberDto);
+
+		memberRepository.updateMember(modifyMemberDto.toEntity(memberId));
+	}
+
+	private void validateModifyMemberDto(ModifyMemberDto modifyMemberDto) {
+		Assert.hasText(modifyMemberDto.getName(), "이름을 입력해야 합니다.");
+		Assert.hasText(modifyMemberDto.getPhone(), "휴대전화를 입력해야 합니다.");
 	}
 
 	private void validateLoginMemberDto(LoginMemberDto loginMemberDto) {

--- a/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
@@ -82,6 +82,15 @@ public class MemberService {
 		memberRepository.updateMember(modifyMemberDto.toEntity(memberId));
 	}
 
+	/**
+	 * 회원 탈퇴
+	 * @param memberId
+	 */
+	@Transactional
+	public void withdrawMember(Long memberId) {
+		memberRepository.updateIsDeleted(memberId);
+	}
+
 	private void validateModifyMemberDto(ModifyMemberDto modifyMemberDto) {
 		Assert.hasText(modifyMemberDto.getName(), "이름을 입력해야 합니다.");
 		Assert.hasText(modifyMemberDto.getPhone(), "휴대전화를 입력해야 합니다.");

--- a/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/idolu/domain/member/service/MemberService.java
@@ -29,11 +29,6 @@ public class MemberService {
 	private final PasswordEncoder passwordEncoder;
 	private final HttpSession httpSession;
 
-	/**
-	 * 회원가입 메서드
-	 * @param signUpMemberDto 사용자 입력 정보
-	 * @return
-	 */
 	@Transactional
 	public Long signUp(SignUpMemberDto signUpMemberDto) {
 		validateMemberDto(signUpMemberDto);
@@ -46,10 +41,6 @@ public class MemberService {
 		return memberRepository.insertMember(member);
 	}
 
-	/**
-	 * 로그인 메서드
-	 * @param loginMemberDto 이메일 및 비밀번호 정보
-	 */
 	@Transactional(readOnly = true)
 	public void login(LoginMemberDto loginMemberDto) {
 		validateLoginMemberDto(loginMemberDto);
@@ -82,10 +73,6 @@ public class MemberService {
 		memberRepository.updateMember(modifyMemberDto.toEntity(memberId));
 	}
 
-	/**
-	 * 회원 탈퇴
-	 * @param memberId
-	 */
 	@Transactional
 	public void withdrawMember(Long memberId) {
 		memberRepository.updateIsDeleted(memberId);

--- a/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
+++ b/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.flab.idolu.domain.member.exception.EmailDuplicateException;
 import com.flab.idolu.domain.member.exception.MemberNotFoundException;
 import com.flab.idolu.domain.member.exception.PasswordNotMatchException;
+import com.flab.idolu.domain.member.exception.UnauthorizedMemberException;
 import com.flab.idolu.global.common.ResponseMessage;
 
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +48,14 @@ public class ExceptionAdvice {
 	@ExceptionHandler(PasswordNotMatchException.class)
 	protected ResponseEntity<ResponseMessage> memberNotFoundException(PasswordNotMatchException exception) {
 		return ResponseEntity.badRequest()
+			.body(ResponseMessage.builder()
+				.message(exception.getMessage())
+				.build());
+	}
+
+	@ExceptionHandler(UnauthorizedMemberException.class)
+	protected ResponseEntity<ResponseMessage> unauthorizedMemberException(UnauthorizedMemberException exception) {
+		return ResponseEntity.status(UNAUTHORIZED)
 			.body(ResponseMessage.builder()
 				.message(exception.getMessage())
 				.build());

--- a/src/main/java/com/flab/idolu/global/annotation/MemberLoginCheck.java
+++ b/src/main/java/com/flab/idolu/global/annotation/MemberLoginCheck.java
@@ -1,0 +1,11 @@
+package com.flab.idolu.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface MemberLoginCheck {
+}

--- a/src/main/java/com/flab/idolu/global/aop/AuthCheckAspect.java
+++ b/src/main/java/com/flab/idolu/global/aop/AuthCheckAspect.java
@@ -16,10 +16,6 @@ import jakarta.servlet.http.HttpSession;
 @Component
 public class AuthCheckAspect {
 
-	/**
-	 * 로그인 상태 확인
-	 * @param joinPoint
-	 */
 	@Before("@annotation(com.flab.idolu.global.annotation.MemberLoginCheck)")
 	public void memberLoginCheck(JoinPoint joinPoint) {
 

--- a/src/main/java/com/flab/idolu/global/aop/AuthCheckAspect.java
+++ b/src/main/java/com/flab/idolu/global/aop/AuthCheckAspect.java
@@ -1,0 +1,34 @@
+package com.flab.idolu.global.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.flab.idolu.domain.member.exception.UnauthorizedMemberException;
+import com.flab.idolu.global.util.SessionUtil;
+
+import jakarta.servlet.http.HttpSession;
+
+@Aspect
+@Component
+public class AuthCheckAspect {
+
+	/**
+	 * 로그인 상태 확인
+	 * @param joinPoint
+	 */
+	@Before("@annotation(com.flab.idolu.global.annotation.MemberLoginCheck)")
+	public void memberLoginCheck(JoinPoint joinPoint) {
+
+		HttpSession session = ((ServletRequestAttributes)(RequestContextHolder.currentRequestAttributes())).getRequest()
+			.getSession();
+
+		Long memberId = SessionUtil.getLoginMemberId(session);
+		if (memberId == null) {
+			throw new UnauthorizedMemberException("로그인이 필요합니다.");
+		}
+	}
+}

--- a/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
@@ -34,4 +34,11 @@
         FROM member
         WHERE id = #{id}
     </select>
+
+    <update id="updateMember" parameterType="Member">
+        UPDATE member
+        SET name  = #{name},
+            phone = #{phone}
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
@@ -37,8 +37,9 @@
 
     <update id="updateMember" parameterType="Member">
         UPDATE member
-        SET name  = #{name},
-            phone = #{phone}
+        SET name       = #{name},
+            phone      = #{phone},
+            updated_at = now()
         WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
@@ -42,4 +42,10 @@
             updated_at = now()
         WHERE id = #{id}
     </update>
+
+    <update id="updateIsDeleted">
+        UPDATE member
+        SET is_deleted = true
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/mamber/MemberMapper.xml
@@ -20,4 +20,18 @@
         FROM member
         WHERE email = #{email}
     </select>
+
+    <select id="findById" resultType="Member">
+        SELECT id,
+               email,
+               password,
+               name,
+               phone,
+               role,
+               is_deleted,
+               created_at,
+               updated_at
+        FROM member
+        WHERE id = #{id}
+    </select>
 </mapper>

--- a/src/test/groovy/com/flab/idolu/domain/fixture/MemberFixture.java
+++ b/src/test/groovy/com/flab/idolu/domain/fixture/MemberFixture.java
@@ -1,6 +1,7 @@
 package com.flab.idolu.domain.fixture;
 
 import com.flab.idolu.domain.member.dto.request.LoginMemberDto;
+import com.flab.idolu.domain.member.dto.request.ModifyMemberDto;
 import com.flab.idolu.domain.member.dto.request.SignUpMemberDto;
 import com.flab.idolu.domain.member.entity.Member;
 import com.flab.idolu.domain.member.entity.Role;
@@ -129,5 +130,20 @@ public class MemberFixture {
 	public static final LoginMemberDto BLANK_PASSWORD_LOGIN_MEMBER = LoginMemberDto.builder()
 		.email("testUser@email.com")
 		.password("")
+		.build();
+
+	public static final ModifyMemberDto DEFAULT_MODIFY_MEMBER = ModifyMemberDto.builder()
+		.name("testUser123")
+		.phone("01011111111")
+		.build();
+
+	public static final ModifyMemberDto BLANK_NAME_MODIFY_MEMBER = ModifyMemberDto.builder()
+		.name("")
+		.phone("01011111111")
+		.build();
+
+	public static final ModifyMemberDto BLANK_PHONE_MODIFY_MEMBER = ModifyMemberDto.builder()
+		.name("testUser123")
+		.phone("")
 		.build();
 }

--- a/src/test/groovy/com/flab/idolu/domain/member/service/MemberServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/member/service/MemberServiceTest.groovy
@@ -178,4 +178,12 @@ class MemberServiceTest extends Specification {
         BLANK_NAME_MODIFY_MEMBER  | "이름을 입력해야 합니다."
         BLANK_PHONE_MODIFY_MEMBER | "휴대전화를 입력해야 합니다."
     }
+
+    def "회원 탈퇴 성공 테스트"() {
+        when:
+        memberService.withdrawMember(1L)
+
+        then:
+        1 * memberRepository.updateIsDeleted(1L)
+    }
 }

--- a/src/test/groovy/com/flab/idolu/domain/member/service/MemberServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/member/service/MemberServiceTest.groovy
@@ -131,4 +131,29 @@ class MemberServiceTest extends Specification {
         then:
         SessionUtil.getLoginMemberId(httpSession) == null
     }
+
+    def "회원정보 조회 테스트"() {
+        given:
+        memberRepository.findById(_) >> Optional.ofNullable(DEFAULT_MEMBER)
+
+        when:
+        def member = memberService.getMemberInfo(1L)
+
+        then:
+        member.email == "testUser@email.com"
+        member.name == "testUser1"
+        member.phone == "01011111111"
+    }
+
+    def "회원정보 실패 테스트"() {
+        given:
+        memberRepository.findById(_) >> Optional.empty()
+
+        when:
+        memberService.getMemberInfo(1L)
+
+        then:
+        def exception = thrown(MemberNotFoundException)
+        exception.message == "존재하지 않는 회원입니다."
+    }
 }

--- a/src/test/groovy/com/flab/idolu/domain/member/service/MemberServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/member/service/MemberServiceTest.groovy
@@ -156,4 +156,26 @@ class MemberServiceTest extends Specification {
         def exception = thrown(MemberNotFoundException)
         exception.message == "존재하지 않는 회원입니다."
     }
+
+    def "회원정보 수정 성공 테스트"() {
+        when:
+        memberService.modifyMemberInfo(DEFAULT_MODIFY_MEMBER, 1L)
+
+        then:
+        1 * memberRepository.updateMember(DEFAULT_MEMBER)
+    }
+
+    def "회원정보 수정 실패 테스트"() {
+        when:
+        memberService.modifyMemberInfo(member, 1L)
+
+        then:
+        def exception = thrown(IllegalArgumentException)
+        exception.message == exceptionMessage
+
+        where:
+        member                    | exceptionMessage
+        BLANK_NAME_MODIFY_MEMBER  | "이름을 입력해야 합니다."
+        BLANK_PHONE_MODIFY_MEMBER | "휴대전화를 입력해야 합니다."
+    }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 주요 변경사항
- 사용자의 정보 조회 및 수정에 대한 기능을 구현했습니다.
- AOP를 통해 사용자 로그인 상태를 체크했습니다.
  - 로그인이 필요한 경우에는 UnauthroizedException 예외를 발생하도록 만들었습니다.


### 관련 이슈
- https://github.com/f-lab-edu/i-dol-u/issues/3

### 참고사항
- 추후에 spring session을 이용하면서 Service Layer에 있는 Session을 Presentation Layer로 리팩토링할 예정입니다.