### PR TITLE
[#15] 로깅을 위한 MDCFilter 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+log/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
+++ b/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
@@ -22,6 +22,7 @@ public class ExceptionAdvice {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	protected ResponseEntity<ResponseMessage> illegalArgumentException(IllegalArgumentException exception) {
+		log.info("IllegalArgumentException: {}", exception.getMessage());
 		return ResponseEntity.status(BAD_REQUEST)
 			.body(ResponseMessage.builder()
 				.status(FAIL)
@@ -31,6 +32,7 @@ public class ExceptionAdvice {
 
 	@ExceptionHandler(EmailDuplicateException.class)
 	protected ResponseEntity<ResponseMessage> emailDuplicationException(EmailDuplicateException exception) {
+		log.info("EmailDuplicateException: {}", exception.getMessage());
 		return ResponseEntity.status(BAD_REQUEST)
 			.body(ResponseMessage.builder()
 				.status(FAIL)
@@ -40,6 +42,7 @@ public class ExceptionAdvice {
 
 	@ExceptionHandler(MemberNotFoundException.class)
 	protected ResponseEntity<ResponseMessage> memberNotFoundException(MemberNotFoundException exception) {
+		log.info("MemberNotFoundException: {}", exception.getMessage());
 		return ResponseEntity.badRequest()
 			.body(ResponseMessage.builder()
 				.status(FAIL)
@@ -49,6 +52,7 @@ public class ExceptionAdvice {
 
 	@ExceptionHandler(PasswordNotMatchException.class)
 	protected ResponseEntity<ResponseMessage> memberNotFoundException(PasswordNotMatchException exception) {
+		log.info("PasswordNotMatchException: {}", exception.getMessage());
 		return ResponseEntity.badRequest()
 			.body(ResponseMessage.builder()
 				.status(FAIL)
@@ -58,6 +62,7 @@ public class ExceptionAdvice {
 
 	@ExceptionHandler(UnauthorizedMemberException.class)
 	protected ResponseEntity<ResponseMessage> unauthorizedMemberException(UnauthorizedMemberException exception) {
+		log.info("UnauthorizedMemberException: {}", exception.getMessage());
 		return ResponseEntity.status(UNAUTHORIZED)
 			.body(ResponseMessage.builder()
 				.status(FAIL)
@@ -66,7 +71,8 @@ public class ExceptionAdvice {
 	}
 
 	@ExceptionHandler(AddressNotFoundException.class)
-	protected ResponseEntity<ResponseMessage> unauthorizedMemberException(AddressNotFoundException exception) {
+	protected ResponseEntity<ResponseMessage> addressNotFoundException(AddressNotFoundException exception) {
+		log.info("AddressNotFoundException: {}", exception.getMessage());
 		return ResponseEntity.status(BAD_REQUEST)
 			.body(ResponseMessage.builder()
 				.status(FAIL)

--- a/src/main/java/com/flab/idolu/global/filter/MDCLoggingFilter.java
+++ b/src/main/java/com/flab/idolu/global/filter/MDCLoggingFilter.java
@@ -1,0 +1,32 @@
+package com.flab.idolu.global.filter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MDCLoggingFilter extends OncePerRequestFilter {
+
+	private static String REQUEST_ID = "request_id";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		UUID uuid = UUID.randomUUID();
+		MDC.put(REQUEST_ID, uuid.toString());
+		filterChain.doFilter(request, response);
+		MDC.clear();
+	}
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProfile name="!prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level)
+                    %boldWhite([%C.%M:%yellow(%L)]) - %msg%n
+                </pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss}:%-4relative %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
     <springProfile name="!prod">
-        <property name="LOG_PATTERN"
-                  value="[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss}:%-4relative %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
-        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder>
-                <pattern>${LOG_PATTERN}</pattern>
-            </encoder>
-        </appender>
+        <include resource="./logback/console-appender.xml"/>
 
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <include resource="./logback/file-info-appender.xml"/>
+        <include resource="./logback/file-warn-appender.xml"/>
+        <include resource="./logback/file-error-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE-INFO"/>
+            <appender-ref ref="FILE-WARN"/>
+            <appender-ref ref="FILE-ERROR"/>
         </root>
     </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
     <springProfile name="!prod">
+        <property name="LOG_PATTERN"
+                  value="[%X{request_id:-startup}] %d{yyyy-MM-dd HH:mm:ss}:%-4relative %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level)
-                    %boldWhite([%C.%M:%yellow(%L)]) - %msg%n
-                </pattern>
+                <pattern>${LOG_PATTERN}</pattern>
             </encoder>
         </appender>
 

--- a/src/main/resources/logback/console-appender.xml
+++ b/src/main/resources/logback/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback/file-error-appender.xml
+++ b/src/main/resources/logback/file-error-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/error/error-${BY_DATE}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback/file-info-appender.xml
+++ b/src/main/resources/logback/file-info-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/info/info-${BY_DATE}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./backup/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback/file-warn-appender.xml
+++ b/src/main/resources/logback/file-warn-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./log/warn/warn-${BY_DATE}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>


### PR DESCRIPTION
## 주요 변경사항
- 테스트, 개발 환경에서는 Info 레벨 로그를 Console에 기록하도록 구현했습니다.
- 프로덕션 환경에서는 Info, Warn, Error 레벨 별 로그를 파일로 기록하도록 구현했습니다.
- MDCFilter를 통해 각 로그들에 대한 식별자를 적용해서 구분할 수 있도록 구현했습니다.