### PR TITLE
[#29] 상품 조회 기능 구현하기

### DIFF
--- a/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
+++ b/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
@@ -21,8 +21,8 @@ public class ProductController {
 
 	@GetMapping
 	public ResponseMessage getProductsByCategoryAndIDol(
-		@RequestParam(required = false) Integer categoryId,
-		@RequestParam(required = false) Integer iDolId,
+		@RequestParam(required = false) Long categoryId,
+		@RequestParam(required = false) Long iDolId,
 		@RequestParam(defaultValue = "0") int offset,
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(defaultValue = "DATE") String order

--- a/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
+++ b/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
@@ -1,0 +1,36 @@
+package com.flab.idolu.domain.product.controller;
+
+import static com.flab.idolu.global.common.ResponseMessage.Status.*;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.idolu.domain.product.service.ProductService;
+import com.flab.idolu.global.common.ResponseMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+	private final ProductService productService;
+
+	@GetMapping
+	public ResponseMessage getProductsByCategoryAndIDol(
+		@RequestParam(required = false) Integer categoryId,
+		@RequestParam(required = false) Integer iDolId,
+		@RequestParam(defaultValue = "0") int offset,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(defaultValue = "DATE") String order
+	) {
+
+		return ResponseMessage.builder()
+			.status(SUCCESS)
+			.result(productService.findByCategoryIdAndIDolId(categoryId, iDolId, offset, size, order))
+			.build();
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
+++ b/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.flab.idolu.domain.product.controller;
 
 import static com.flab.idolu.global.common.ResponseMessage.Status.*;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +21,7 @@ public class ProductController {
 	private final ProductService productService;
 
 	@GetMapping
-	public ResponseMessage getProductsByCategoryAndIDol(
+	public ResponseEntity<ResponseMessage> getProductsByCategoryAndIDol(
 		@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false) Long iDolId,
 		@RequestParam(defaultValue = "0") int offset,
@@ -28,9 +29,9 @@ public class ProductController {
 		@RequestParam(defaultValue = "DATE") String order
 	) {
 
-		return ResponseMessage.builder()
+		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)
 			.result(productService.findByCategoryIdAndIDolId(categoryId, iDolId, offset, size, order))
-			.build();
+			.build());
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/product/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/flab/idolu/domain/product/dto/response/ProductListResponseDto.java
@@ -1,0 +1,19 @@
+package com.flab.idolu.domain.product.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductListResponseDto {
+
+	private Long id;
+	private Long categoryId;
+	private Long iDolId;
+	private String name;
+	private BigDecimal price;
+	private Integer stock;
+	private String imageUrl;
+}

--- a/src/main/java/com/flab/idolu/domain/product/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/flab/idolu/domain/product/dto/response/ProductListResponseDto.java
@@ -1,0 +1,14 @@
+package com.flab.idolu.domain.product.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductListResponseDto {
+
+	private List<ProductPaginationDto> products;
+	private Long totalCount;
+}

--- a/src/main/java/com/flab/idolu/domain/product/dto/response/ProductPaginationDto.java
+++ b/src/main/java/com/flab/idolu/domain/product/dto/response/ProductPaginationDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ProductListResponseDto {
+public class ProductPaginationDto {
 
 	private Long id;
 	private Long categoryId;

--- a/src/main/java/com/flab/idolu/domain/product/entity/Product.java
+++ b/src/main/java/com/flab/idolu/domain/product/entity/Product.java
@@ -21,6 +21,7 @@ public class Product {
 	private Long iDolId;
 	private String name;
 	private BigDecimal price;
+	private Integer stock;
 	private String imageUrl;
 	private String description;
 	private boolean isDeleted;

--- a/src/main/java/com/flab/idolu/domain/product/entity/Product.java
+++ b/src/main/java/com/flab/idolu/domain/product/entity/Product.java
@@ -1,0 +1,29 @@
+package com.flab.idolu.domain.product.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class Product {
+
+	private Long id;
+	private Long categoryId;
+	private Long iDolId;
+	private String name;
+	private BigDecimal price;
+	private String imageUrl;
+	private String description;
+	private boolean isDeleted;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
@@ -1,0 +1,21 @@
+package com.flab.idolu.domain.product.repository;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
+
+import com.flab.idolu.domain.product.dto.response.ProductListResponseDto;
+
+@Mapper
+@Repository
+public interface ProductRepository {
+
+	List<ProductListResponseDto> findByCategoryIdAndIDolId(
+		@Param("categoryId") Integer categoryId,
+		@Param("iDolId") Integer iDolId,
+		@Param("offset") int offset,
+		@Param("size") int size,
+		@Param("order") String order);
+}

--- a/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
@@ -13,9 +13,11 @@ import com.flab.idolu.domain.product.dto.response.ProductPaginationDto;
 public interface ProductRepository {
 
 	List<ProductPaginationDto> findByCategoryIdAndIDolId(
-		@Param("categoryId") Integer categoryId,
-		@Param("iDolId") Integer iDolId,
+		@Param("categoryId") Long categoryId,
+		@Param("iDolId") Long iDolId,
 		@Param("offset") int offset,
 		@Param("size") int size,
 		@Param("order") String order);
+
+	Long getTotalCountByCategoryIdAndIDolId(@Param("categoryId") Long categoryId, @Param("iDolId") Long iDolId);
 }

--- a/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
@@ -6,13 +6,13 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
-import com.flab.idolu.domain.product.dto.response.ProductListResponseDto;
+import com.flab.idolu.domain.product.dto.response.ProductPaginationDto;
 
 @Mapper
 @Repository
 public interface ProductRepository {
 
-	List<ProductListResponseDto> findByCategoryIdAndIDolId(
+	List<ProductPaginationDto> findByCategoryIdAndIDolId(
 		@Param("categoryId") Integer categoryId,
 		@Param("iDolId") Integer iDolId,
 		@Param("offset") int offset,

--- a/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
+++ b/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
@@ -15,7 +15,7 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 
-	public List<ProductPaginationDto> findByCategoryIdAndIDolId(Integer categoryId, Integer iDolId,
+	public List<ProductPaginationDto> findByCategoryIdAndIDolId(Long categoryId, Long iDolId,
 		int offset, int size, String order) {
 
 		return productRepository.findByCategoryIdAndIDolId(categoryId, iDolId, offset * size, size, order);

--- a/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
+++ b/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.flab.idolu.domain.product.dto.response.ProductListResponseDto;
+import com.flab.idolu.domain.product.dto.response.ProductPaginationDto;
 import com.flab.idolu.domain.product.repository.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 
-	public List<ProductListResponseDto> findByCategoryIdAndIDolId(Integer categoryId, Integer iDolId,
+	public List<ProductPaginationDto> findByCategoryIdAndIDolId(Integer categoryId, Integer iDolId,
 		int offset, int size, String order) {
 
 		return productRepository.findByCategoryIdAndIDolId(categoryId, iDolId, offset * size, size, order);

--- a/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
+++ b/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.flab.idolu.domain.product.dto.response.ProductListResponseDto;
 import com.flab.idolu.domain.product.dto.response.ProductPaginationDto;
 import com.flab.idolu.domain.product.repository.ProductRepository;
 
@@ -15,9 +16,16 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 
-	public List<ProductPaginationDto> findByCategoryIdAndIDolId(Long categoryId, Long iDolId,
+	public ProductListResponseDto findByCategoryIdAndIDolId(Long categoryId, Long iDolId,
 		int offset, int size, String order) {
 
-		return productRepository.findByCategoryIdAndIDolId(categoryId, iDolId, offset * size, size, order);
+		List<ProductPaginationDto> products = productRepository.findByCategoryIdAndIDolId(categoryId,
+			iDolId, offset * size, size, order);
+		Long totalCount = productRepository.getTotalCountByCategoryIdAndIDolId(categoryId, iDolId);
+
+		return ProductListResponseDto.builder()
+			.products(products)
+			.totalCount(totalCount)
+			.build();
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
+++ b/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
@@ -1,0 +1,23 @@
+package com.flab.idolu.domain.product.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.flab.idolu.domain.product.dto.response.ProductListResponseDto;
+import com.flab.idolu.domain.product.repository.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+	private final ProductRepository productRepository;
+
+	public List<ProductListResponseDto> findByCategoryIdAndIDolId(Integer categoryId, Integer iDolId,
+		int offset, int size, String order) {
+
+		return productRepository.findByCategoryIdAndIDolId(categoryId, iDolId, offset * size, size, order);
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
+++ b/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
@@ -3,6 +3,7 @@ package com.flab.idolu.domain.product.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.idolu.domain.product.dto.response.ProductListResponseDto;
 import com.flab.idolu.domain.product.dto.response.ProductPaginationDto;
@@ -16,6 +17,7 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 
+	@Transactional(readOnly = true)
 	public ProductListResponseDto findByCategoryIdAndIDolId(Long categoryId, Long iDolId,
 		int offset, int size, String order) {
 

--- a/src/main/resources/mybatis/mapper/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/mapper/product/ProductMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.idolu.domain.product.repository.ProductRepository">
+
+    <select id="findByCategoryIdAndIDolId" resultType="ProductListResponseDto">
+        SELECT pt.id, category_id, i_dol_id, name, price, stock, image_url
+        FROM product p
+        JOIN (SELECT id
+            FROM product
+            <where>
+                <if test="categoryId != null">AND category_id = #{categoryId}</if>
+                <if test="iDolId != null">AND i_dol_id = #{iDolId}</if>
+            </where>
+            <choose>
+                <when test='order.toString() eq "PRICE_DESC"'>
+                    ORDER BY price DESC
+                </when>
+                <when test='order.toString() eq "PRICE_ASC"'>
+                    ORDER BY price ASC
+                </when>
+                <otherwise>
+                    ORDER BY id DESC
+                </otherwise>
+            </choose>
+            LIMIT #{size}
+            OFFSET #{offset}
+        ) pt ON pt.id = p.id;
+    </select>
+</mapper>

--- a/src/main/resources/mybatis/mapper/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/mapper/product/ProductMapper.xml
@@ -26,4 +26,13 @@
             OFFSET #{offset}
         ) pt ON pt.id = p.id;
     </select>
+
+    <select id="getTotalCountByCategoryIdAndIDolId" resultType="Long">
+        SELECT COUNT(*)
+        FROM product
+        <where>
+            <if test="categoryId != null">AND category_id = #{categoryId}</if>
+            <if test="iDolId != null">AND i_dol_id = #{iDolId}</if>
+        </where>
+    </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/mapper/product/ProductMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.flab.idolu.domain.product.repository.ProductRepository">
 
-    <select id="findByCategoryIdAndIDolId" resultType="ProductListResponseDto">
+    <select id="findByCategoryIdAndIDolId" resultType="ProductPaginationDto">
         SELECT pt.id, category_id, i_dol_id, name, price, stock, image_url
         FROM product p
         JOIN (SELECT id

--- a/src/test/groovy/com/flab/idolu/domain/product/service/ProductServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/product/service/ProductServiceTest.groovy
@@ -1,0 +1,28 @@
+package com.flab.idolu.domain.product.service
+
+
+import com.flab.idolu.domain.product.repository.ProductRepository
+import spock.lang.Specification
+
+class ProductServiceTest extends Specification {
+
+    ProductService productService;
+    ProductRepository productRepository = Mock();
+
+    def setup() {
+        productService = new ProductService(productRepository)
+    }
+
+    def "카테고리 및 아이돌별 상품 조회"() {
+        given:
+        productRepository.findByCategoryIdAndIDolId(_, _, _, _, _) >> List.of(_, _, _)
+        productRepository.getTotalCountByCategoryIdAndIDolId(_, _) >> 3
+
+        when:
+        def productListResponseDto = productService.findByCategoryIdAndIDolId(1L, 1L, 1, 3, "DATE")
+
+        then:
+        productListResponseDto.products.size() == 3
+        productListResponseDto.totalCount == 3
+    }
+}


### PR DESCRIPTION
### 주요 변경사항

- 카테고리별 아이돌별로 상품 목록을 조회할 수 있도록 구현했습니다.
- 상품 목록을 최신순, 높은 가격순, 낮은 가격순으로 조회할 수 있도록 구현했습니다.
- 프론트에서 페이지 개수를 구하기 위해 상품 총 개수도 반환시키도록 구현했습니다.
- 상품 페이지네이션 구현 시 covering index를 통해 성능을 향상시켰습니다.
  - 관련 블로그: [페이징 성능 개선: offset vs no offset vs covering index](https://oneny.tistory.com/110)

### 관련 이슈

- https://github.com/f-lab-edu/i-dol-u/issues/29