### PR TITLE
[#39] 비관적 락과 분산 락을 사용한 단일 상품 재고 차감 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flab/idolu/domain/order/service/OrderService.java
+++ b/src/main/java/com/flab/idolu/domain/order/service/OrderService.java
@@ -50,9 +50,8 @@ public class OrderService {
 	}
 
 	private void validatePaymentType(String paymentType) {
-		Arrays.stream(PaymentType.values())
-			.filter(type -> type.name().equals(paymentType))
-			.findAny()
-			.orElseThrow(() -> new IllegalArgumentException("%s에 해당하는 결제 타입이 없습니다.".formatted(paymentType)));
+		if (Arrays.stream(PaymentType.values()).noneMatch(type -> type.name().equals(paymentType))) {
+			throw new IllegalArgumentException("%s에 해당하는 결제 타입이 없습니다.".formatted(paymentType));
+		}
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
+++ b/src/main/java/com/flab/idolu/domain/product/controller/ProductController.java
@@ -4,10 +4,13 @@ import static com.flab.idolu.global.common.ResponseMessage.Status.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.flab.idolu.domain.product.dto.request.ProductRequest;
 import com.flab.idolu.domain.product.service.ProductService;
 import com.flab.idolu.global.common.ResponseMessage;
 
@@ -32,6 +35,26 @@ public class ProductController {
 		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)
 			.result(productService.findByCategoryIdAndIDolId(categoryId, iDolId, offset, size, order))
+			.build());
+	}
+
+	@PostMapping("/pessimisticLock")
+	public ResponseEntity<ResponseMessage> decreaseStockWithPessimisticLock(
+		@RequestBody ProductRequest productRequest) {
+
+		productService.decreaseStockWithPessimisticLock(productRequest.getProductId(), productRequest.getQuantity());
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
+			.build());
+	}
+
+	@PostMapping("/distributedLock")
+	public ResponseEntity<ResponseMessage> decreaseStockWithDistributedLock(
+		@RequestBody ProductRequest productRequest) {
+
+		productService.decreaseStockWithDistributedLock(productRequest.getProductId(), productRequest.getQuantity());
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
 			.build());
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/product/dto/request/ProductRequest.java
+++ b/src/main/java/com/flab/idolu/domain/product/dto/request/ProductRequest.java
@@ -1,0 +1,12 @@
+package com.flab.idolu.domain.product.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductRequest {
+
+	private Long productId;
+	private Integer quantity;
+}

--- a/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/flab/idolu/domain/product/repository/ProductRepository.java
@@ -3,6 +3,8 @@ package com.flab.idolu.domain.product.repository;
 import java.util.List;
 import java.util.Optional;
 
+import javax.swing.text.html.Option;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
@@ -28,4 +30,8 @@ public interface ProductRepository {
 	Optional<Product> findById(Long id);
 
 	void updateProductStocks(List<Product> product);
+
+	Optional<Product> findByIdForUpdate(Long id);
+
+	void updateProductStock(Product product);
 }

--- a/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
+++ b/src/main/java/com/flab/idolu/domain/product/service/ProductService.java
@@ -48,12 +48,7 @@ public class ProductService {
 		Product product = productRepository.findByIdForUpdate(id)
 			.orElseThrow(() -> new ProductNotFoundException("상품이 없습니다."));
 
-		if (product.getStock() < purchaseQuantity) {
-			throw new InsufficientStockException("재고는 0개 미만이 될 수 없습니다.");
-		}
-
-		product.decreaseStock(purchaseQuantity);
-		productRepository.updateProductStock(product);
+		decreaseStock(product, purchaseQuantity);
 	}
 
 	@DistributedLock(lockName = "stockLock", identifier = "id")
@@ -61,12 +56,7 @@ public class ProductService {
 		Product product = productRepository.findById(id)
 			.orElseThrow(() -> new ProductNotFoundException("상품이 없습니다."));
 
-		if (product.getStock() < purchaseQuantity) {
-			throw new InsufficientStockException("재고는 0개 미만이 될 수 없습니다.");
-		}
-
-		product.decreaseStock(purchaseQuantity);
-		productRepository.updateProductStock(product);
+		decreaseStock(product, purchaseQuantity);
 	}
 
 	private void decreaseProductsStock(List<Product> requestProducts, List<Product> findProducts) {
@@ -85,5 +75,14 @@ public class ProductService {
 			.filter(findProduct -> findProduct.equals(product))
 			.findAny()
 			.orElseThrow(() -> new ProductNotFoundException("상품이 없습니다."));
+	}
+
+	private void decreaseStock(Product product, int purchaseQuantity) {
+		if (product.getStock() < purchaseQuantity) {
+			throw new InsufficientStockException("재고는 0개 미만이 될 수 없습니다.");
+		}
+
+		product.decreaseStock(purchaseQuantity);
+		productRepository.updateProductStock(product);
 	}
 }

--- a/src/main/java/com/flab/idolu/global/annotation/DistributedLock.java
+++ b/src/main/java/com/flab/idolu/global/annotation/DistributedLock.java
@@ -1,0 +1,22 @@
+package com.flab.idolu.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+	String lockName(); // 락의 이름
+
+	String identifier(); // 분산락을 걸 파라미터 네임
+
+	TimeUnit timeUnit() default TimeUnit.SECONDS; // 락의 시간 단위
+
+	long waitTime() default 15L; // 락 대기 시간
+
+	long leaseTime() default 14L; // 락 임대 시간
+}

--- a/src/main/java/com/flab/idolu/global/aop/DistributedLockAop.java
+++ b/src/main/java/com/flab/idolu/global/aop/DistributedLockAop.java
@@ -1,0 +1,66 @@
+package com.flab.idolu.global.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import com.flab.idolu.global.annotation.DistributedLock;
+import com.flab.idolu.global.common.AopForTransaction;
+import com.flab.idolu.global.exception.RedissonLockTimeoutException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+
+	private final RedissonClient redissonClient;
+	private final AopForTransaction aopForTransaction;
+
+	@Around("@annotation(com.flab.idolu.global.annotation.DistributedLock)")
+	public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		Method method = signature.getMethod();
+		DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+		String baseKey = distributedLock.lockName();
+		String dynamicKey = generateDynamicKey(signature.getParameterNames(), joinPoint.getArgs(),
+			distributedLock.identifier());
+		RLock rLock = redissonClient.getLock(baseKey + ":" + dynamicKey);
+
+		try {
+			boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(),
+				distributedLock.timeUnit());
+			if (!available) {
+				throw new RedissonLockTimeoutException("Redisson Lock을 획득하지 못했습니다.");
+			}
+
+			return aopForTransaction.proceed(joinPoint);
+		} finally {
+			try {
+				rLock.unlock();
+			} catch (IllegalMonitorStateException e) { // leaseTime이 지난 경우 자동 해제가 되는데 unlock 시도 시 발생
+				log.info(e + baseKey + dynamicKey);
+			}
+		}
+	}
+
+	private String generateDynamicKey(String[] parameterNames, Object[] args, String identifier) {
+		for (int i = 0; i < parameterNames.length; i++) {
+			if (parameterNames[i].equals(identifier)) {
+				return String.valueOf(args[i]);
+			}
+		}
+
+		throw new IllegalArgumentException("해당하는 identifier가 없습니다.");
+	}
+}

--- a/src/main/java/com/flab/idolu/global/common/AopForTransaction.java
+++ b/src/main/java/com/flab/idolu/global/common/AopForTransaction.java
@@ -1,0 +1,18 @@
+package com.flab.idolu.global.common;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+	/**
+	 * 트랜잭션을 호출한 상위 콜스택에서 발생하기 때문에
+	 * leaseTime 보다 트랜잭션 timeout을 작게 설정해야 leaseTimeout 전에 rollback 실행
+	 */
+	@Transactional(timeout = 13)
+	public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+		return joinPoint.proceed();
+	}
+}

--- a/src/main/java/com/flab/idolu/global/config/RedisSessionConfig.java
+++ b/src/main/java/com/flab/idolu/global/config/RedisSessionConfig.java
@@ -15,13 +15,13 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 @EnableRedisHttpSession
 public class RedisSessionConfig {
 
-	@Value("${spring.data.redis.host}")
+	@Value("${spring.data.redis.session.host}")
 	private String redisSessionHost;
 
-	@Value("${spring.data.redis.port}")
+	@Value("${spring.data.redis.session.port}")
 	private int redisSessionPort;
 
-	@Value("${spring.data.redis.password}")
+	@Value("${spring.data.redis.session.password}")
 	private String redisPassword;
 
 	@Bean

--- a/src/main/java/com/flab/idolu/global/config/RedissonConfig.java
+++ b/src/main/java/com/flab/idolu/global/config/RedissonConfig.java
@@ -1,0 +1,36 @@
+package com.flab.idolu.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.SingleServerConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Value("${spring.data.redis.redisson.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.redisson.port}")
+	private int redisPort;
+
+	@Value("${spring.data.redis.redisson.password}")
+	private String redisPassword;
+
+	private static final String REDISSON_HOST_PREFIX = "redis://";
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		SingleServerConfig singleServerConfig = config.useSingleServer()
+			.setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+		if (!redisPassword.isEmpty()) {
+			singleServerConfig.setPassword(redisPassword);
+		}
+
+		return Redisson.create(config);
+	}
+}

--- a/src/main/java/com/flab/idolu/global/config/RedissonConfig.java
+++ b/src/main/java/com/flab/idolu/global/config/RedissonConfig.java
@@ -25,11 +25,9 @@ public class RedissonConfig {
 	@Bean
 	public RedissonClient redissonClient() {
 		Config config = new Config();
-		SingleServerConfig singleServerConfig = config.useSingleServer()
-			.setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
-		if (!redisPassword.isEmpty()) {
-			singleServerConfig.setPassword(redisPassword);
-		}
+		config.useSingleServer()
+			.setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
+			.setPassword(redisPassword);
 
 		return Redisson.create(config);
 	}

--- a/src/main/java/com/flab/idolu/global/exception/RedissonLockTimeoutException.java
+++ b/src/main/java/com/flab/idolu/global/exception/RedissonLockTimeoutException.java
@@ -1,0 +1,8 @@
+package com.flab.idolu.global.exception;
+
+public class RedissonLockTimeoutException extends RuntimeException {
+
+	public RedissonLockTimeoutException(String message) {
+		super(message);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,14 @@ spring:
     password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
   data:
     redis:
-      host: ENC(ItcOHb8ScqGMgddHtdmOvWENNiyPIm+U)
-      port: ENC(wGSwwvSRNC7IppcI+oLeKA==)
-      password: ENC(CfXONUwAUri6U2vKhaaFE5Hvcqm/ArWF)
+      session:
+        host: ENC(ItcOHb8ScqGMgddHtdmOvWENNiyPIm+U)
+        port: ENC(wGSwwvSRNC7IppcI+oLeKA==)
+        password: ENC(CfXONUwAUri6U2vKhaaFE5Hvcqm/ArWF)
+      redisson:
+        host: ENC(ItcOHb8ScqGMgddHtdmOvWENNiyPIm+U)
+        port: ENC(wGSwwvSRNC7IppcI+oLeKA==)
+        password: ENC(CfXONUwAUri6U2vKhaaFE5Hvcqm/ArWF)
 mybatis:
   type-aliases-package: com.flab.idolu.domain.*.entity, com.flab.idolu.domain.*.dto.response
   configuration:
@@ -36,10 +41,14 @@ spring:
     password: ENC(YEslivkCss7owXDEzcufYjDhOpGmh12f)
   data:
     redis:
-      host: ENC(X5l3B3IOUY0jRMkCuayh2gqCPCD6mIf9)
-      port: ENC(HdD4vqgrg4X5YTE26mKNkw==)
-      password: ENC(1KIy5fYk1jIpW44zkkL8qs7uI5motiCK)
-
+      session:
+        host: ENC(X5l3B3IOUY0jRMkCuayh2gqCPCD6mIf9)
+        port: ENC(HdD4vqgrg4X5YTE26mKNkw==)
+        password: ENC(1KIy5fYk1jIpW44zkkL8qs7uI5motiCK)
+      redisson:
+        host: ENC(TrfcBZ8PP/oISfKbZSWdgYJKdlD9cEGk)
+        port: ENC(c5iRyJ4GwRKRoq+WLflDnw==)
+        password: ENC(Z3IjH25WfR+sU366bFXp9opPir89caX3)
 server:
   port: 8080
 
@@ -55,10 +64,14 @@ spring:
     username: ENC(v1Qf/pZcdMx6bZ2sth8h2A==)
     password: ENC(YEslivkCss7owXDEzcufYjDhOpGmh12f)
   data:
-    redis:
+    session:
       host: ENC(X5l3B3IOUY0jRMkCuayh2gqCPCD6mIf9)
       port: ENC(HdD4vqgrg4X5YTE26mKNkw==)
       password: ENC(1KIy5fYk1jIpW44zkkL8qs7uI5motiCK)
+    redisson:
+      host: ENC(TrfcBZ8PP/oISfKbZSWdgYJKdlD9cEGk)
+      port: ENC(c5iRyJ4GwRKRoq+WLflDnw==)
+      password: ENC(Z3IjH25WfR+sU366bFXp9opPir89caX3)
 
 server:
   port: 8081

--- a/src/main/resources/mybatis/mapper/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/mapper/product/ProductMapper.xml
@@ -60,4 +60,18 @@
             WHERE id = #{product.id}
         </foreach>
     </update>
+
+    <select id="findByIdForUpdate" resultType="Product">
+        SELECT *
+        FROM product
+        WHERE id = #{id}
+            FOR UPDATE
+    </select>
+
+    <update id="updateProductStock">
+        UPDATE product
+        SET stock      = #{stock},
+            updated_at = now()
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/test/groovy/com/flab/idolu/domain/fixture/ProductFixture.java
+++ b/src/test/groovy/com/flab/idolu/domain/fixture/ProductFixture.java
@@ -27,4 +27,20 @@ public class ProductFixture {
 		.name("productA")
 		.stock(3)
 		.build();
+
+	public static Product DEFAULT_PRODUCT_FOR_UPDATE = Product.builder()
+		.id(1L)
+		.categoryId(1L)
+		.iDolId(1L)
+		.name("productA")
+		.stock(3)
+		.build();
+
+	public static Product DEFAULT_PRODUCT_DISTRIBUTED_LOCK = Product.builder()
+		.id(1L)
+		.categoryId(1L)
+		.iDolId(1L)
+		.name("productA")
+		.stock(3)
+		.build();
 }

--- a/src/test/groovy/com/flab/idolu/domain/product/service/ProductServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/product/service/ProductServiceTest.groovy
@@ -1,12 +1,14 @@
 package com.flab.idolu.domain.product.service
 
-import com.flab.idolu.domain.fixture.ProductFixture
+import com.flab.idolu.domain.product.entity.Product
 import com.flab.idolu.domain.product.exception.InsufficientStockException
 import com.flab.idolu.domain.product.exception.ProductNotFoundException
 import com.flab.idolu.domain.product.repository.ProductRepository
 import spock.lang.Specification
 
 import static com.flab.idolu.domain.fixture.ProductFixture.DEFAULT_PRODUCT
+import static com.flab.idolu.domain.fixture.ProductFixture.DEFAULT_PRODUCT_DISTRIBUTED_LOCK
+import static com.flab.idolu.domain.fixture.ProductFixture.DEFAULT_PRODUCT_FOR_UPDATE
 import static com.flab.idolu.domain.fixture.ProductFixture.INSUFFICIENT_PRODUCT
 
 class ProductServiceTest extends Specification {
@@ -62,6 +64,67 @@ class ProductServiceTest extends Specification {
 
         when:
         productService.decreaseProductStocks(List.of(DEFAULT_PRODUCT))
+
+        then:
+        def product = productRepository.findById(1L)
+        product.get().stock == 0
+    }
+
+    def "비관적 락을 사용한 재고 차감 실패 테스트: 상품 없음"() {
+        given:
+        productRepository.findByIdForUpdate(1L) >> Optional.empty()
+
+        when:
+        productService.decreaseStockWithPessimisticLock(1L, 1)
+
+        then:
+        def exception = thrown(ProductNotFoundException)
+        exception.message == "상품이 없습니다."
+    }
+
+    def "비관적 락을 사용한 재고 차감 실패 테스트: 재고 부족"() {
+        given:
+        productRepository.findByIdForUpdate(1L) >> Optional.of(DEFAULT_PRODUCT)
+
+        when:
+        productService.decreaseStockWithPessimisticLock(1L, 10)
+
+        then:
+        def exception = thrown(InsufficientStockException)
+        exception.message == "재고는 0개 미만이 될 수 없습니다."
+    }
+
+    def "비관적 락을 사용한 재고 차감 성공"() {
+        given:
+        productRepository.findByIdForUpdate(1L) >> Optional.of(DEFAULT_PRODUCT_FOR_UPDATE)
+        productRepository.findById(1L) >> Optional.of(DEFAULT_PRODUCT_FOR_UPDATE)
+
+        when:
+        productService.decreaseStockWithPessimisticLock(1L, 3)
+
+        then:
+        def product = productRepository.findById(1L)
+        product.get().stock == 0
+    }
+
+    def "분산 락을 사용한 재고 차감 실패 테스트: 상품 없음"() {
+        given:
+        productRepository.findById(1L) >> Optional.empty()
+
+        when:
+        productService.decreaseStockWithDistributedLock(1L, 1)
+
+        then:
+        def exception = thrown(ProductNotFoundException)
+        exception.message == "상품이 없습니다."
+    }
+
+    def "분산 락을 사용한 재고 차감 성공"() {
+        given:
+        productRepository.findById(1L) >> Optional.of(DEFAULT_PRODUCT_DISTRIBUTED_LOCK)
+
+        when:
+        productService.decreaseStockWithDistributedLock(1L, 3)
 
         then:
         def product = productRepository.findById(1L)


### PR DESCRIPTION
### 주요 변경사항

- 비관적 락과 분산 락의 성능 차이 비교를 위해 비즈니스 로직을 같게 하기 위해 단일 상품에 대한 재고 차감 기능을 구현했습니다.
- 비관적 락을 사용하는 경우, 상품 조회 시 SELECT ... FOR UPDATE를 통해 배타락을 획득하여 다른 트랜잭션에서는 해당 레코드에 대해 락을 대기하도록 구현했습니다.
- 분산 락을 사용하는 경우, DB 정합성을 위해 분산 락을 획득한 요청 스레드에 대해서만 트랜잭션을 시작하고 커밋을 한 후 분산 락을 반납하도록 구현했습니다.
  - 트랜잭션 timeout이 락 임대 시간(leasetime)보다 긴 경우에는 락 임대 시간을 초과하는 경우 예외는 상위 콜스택으로 전파되기 때문에 IllegalMonitorStateException 발생하더라도 쿼리 요청이 나갈 수 있어 timeout을 락 임대 시간보다 작게 설정했습니다.
  - AOP 기반 컴포넌트를 구성하여 Service 레이어에서는 비즈니스 로직에만 집중할 수 있도록 구현했습니다.

### 관련 이슈

- https://github.com/f-lab-edu/i-dol-u/issues/39