### PR TITLE
[#41] MySQL Replica 서버 구현

### DIFF
--- a/src/main/java/com/flab/idolu/global/config/DataSourceConfig.java
+++ b/src/main/java/com/flab/idolu/global/config/DataSourceConfig.java
@@ -17,8 +17,8 @@ import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 @Profile({"prod1", "prod2"})
 public class DataSourceConfig {
 
-	private static final String SOURCE = "SOURCE";
-	private static final String REPLICA = "REPLICA";
+	private static final String SOURCE = "source";
+	private static final String REPLICA = "replica";
 
 	@Bean
 	@Qualifier(SOURCE)
@@ -42,8 +42,8 @@ public class DataSourceConfig {
 		@Qualifier(REPLICA) DataSource replicaDataSource) {
 
 		HashMap<Object, Object> dataSourceMap = new HashMap<>();
-		dataSourceMap.put("source", sourceDataSource);
-		dataSourceMap.put("replica", replicaDataSource);
+		dataSourceMap.put(SOURCE, sourceDataSource);
+		dataSourceMap.put(REPLICA, replicaDataSource);
 
 		RoutingDataSource routingDataSource = new RoutingDataSource();
 		routingDataSource.setTargetDataSources(dataSourceMap);

--- a/src/main/java/com/flab/idolu/global/config/DataSourceConfig.java
+++ b/src/main/java/com/flab/idolu/global/config/DataSourceConfig.java
@@ -1,0 +1,59 @@
+package com.flab.idolu.global.config;
+
+import java.util.HashMap;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+@Profile({"prod1", "prod2"})
+public class DataSourceConfig {
+
+	private static final String SOURCE = "SOURCE";
+	private static final String REPLICA = "REPLICA";
+
+	@Bean
+	@Qualifier(SOURCE)
+	@ConfigurationProperties(prefix = "spring.datasource.source")
+	public DataSource sourceDataSource() {
+		return DataSourceBuilder.create()
+			.build();
+	}
+
+	@Bean
+	@Qualifier(REPLICA)
+	@ConfigurationProperties(prefix = "spring.datasource.replica")
+	public DataSource replicaDataSource() {
+		return DataSourceBuilder.create()
+			.build();
+	}
+
+	@Bean
+	public RoutingDataSource routingDataSource(
+		@Qualifier(SOURCE) DataSource sourceDataSource,
+		@Qualifier(REPLICA) DataSource replicaDataSource) {
+
+		HashMap<Object, Object> dataSourceMap = new HashMap<>();
+		dataSourceMap.put("source", sourceDataSource);
+		dataSourceMap.put("replica", replicaDataSource);
+
+		RoutingDataSource routingDataSource = new RoutingDataSource();
+		routingDataSource.setTargetDataSources(dataSourceMap);
+		routingDataSource.setDefaultTargetDataSource(sourceDataSource);
+		return routingDataSource;
+	}
+
+	@Bean
+	@Primary
+	public DataSource dataSource(RoutingDataSource routingDataSource) {
+		return new LazyConnectionDataSourceProxy(routingDataSource);
+	}
+}

--- a/src/main/java/com/flab/idolu/global/config/RoutingDataSource.java
+++ b/src/main/java/com/flab/idolu/global/config/RoutingDataSource.java
@@ -1,0 +1,12 @@
+package com.flab.idolu.global.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+	@Override
+	protected Object determineCurrentLookupKey() {
+		return TransactionSynchronizationManager.isCurrentTransactionReadOnly() ? "replica" : "source";
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,15 +1,9 @@
 spring:
   datasource:
-    source:
-      driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: ENC(qWDwD8bHKhIrpQH3bQztE1PKAr4Ci9oAWu42essW/99Sstla3WW0NQ96J1BDyvnk9QWRVVKL8zLmbrDgTNv1a6yEKXvNXfHx)
-      username: ENC(R5wYtFLPzE8j1dYaLN8JHw==)
-      password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
-    replica:
-      driver-class-name: com.mysql.cj.jdbc.Driver
-      jdbc-url: ENC(qWDwD8bHKhIrpQH3bQztE1PKAr4Ci9oAWu42essW/99Sstla3WW0NQ96J1BDyvnk9QWRVVKL8zLmbrDgTNv1a6yEKXvNXfHx)
-      username: ENC(R5wYtFLPzE8j1dYaLN8JHw==)
-      password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ENC(qWDwD8bHKhIrpQH3bQztE1PKAr4Ci9oAWu42essW/99Sstla3WW0NQ96J1BDyvnk9QWRVVKL8zLmbrDgTNv1a6yEKXvNXfHx)
+    username: ENC(R5wYtFLPzE8j1dYaLN8JHw==)
+    password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
   data:
     redis:
       host: ENC(ItcOHb8ScqGMgddHtdmOvWENNiyPIm+U)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,15 @@
 spring:
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(qWDwD8bHKhIrpQH3bQztE1PKAr4Ci9oAWu42essW/99Sstla3WW0NQ96J1BDyvnk9QWRVVKL8zLmbrDgTNv1a6yEKXvNXfHx)
-    username: ENC(R5wYtFLPzE8j1dYaLN8JHw==)
-    password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
+    source:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ENC(qWDwD8bHKhIrpQH3bQztE1PKAr4Ci9oAWu42essW/99Sstla3WW0NQ96J1BDyvnk9QWRVVKL8zLmbrDgTNv1a6yEKXvNXfHx)
+      username: ENC(R5wYtFLPzE8j1dYaLN8JHw==)
+      password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
+    replica:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ENC(qWDwD8bHKhIrpQH3bQztE1PKAr4Ci9oAWu42essW/99Sstla3WW0NQ96J1BDyvnk9QWRVVKL8zLmbrDgTNv1a6yEKXvNXfHx)
+      username: ENC(R5wYtFLPzE8j1dYaLN8JHw==)
+      password: ENC(2VRZJBlof9rNUyol/Olzw9LAaWzcDfRC)
   data:
     redis:
       host: ENC(ItcOHb8ScqGMgddHtdmOvWENNiyPIm+U)
@@ -30,10 +36,16 @@ spring:
     activate:
       on-profile: prod1
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(bYq1JS4dQAYXjHmn1mDlSPFuiH6jgcX6G7bTFiNTttfKZmfdx+Wz7CtWhZSvkA+7zzN/cWLJxb+VNJLBHYvNLr2Tgc2f5lF5)
-    username: ENC(v1Qf/pZcdMx6bZ2sth8h2A==)
-    password: ENC(YEslivkCss7owXDEzcufYjDhOpGmh12f)
+    source:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ENC(bYq1JS4dQAYXjHmn1mDlSPFuiH6jgcX6G7bTFiNTttfKZmfdx+Wz7CtWhZSvkA+7zzN/cWLJxb+VNJLBHYvNLr2Tgc2f5lF5)
+      username: ENC(v1Qf/pZcdMx6bZ2sth8h2A==)
+      password: ENC(YEslivkCss7owXDEzcufYjDhOpGmh12f)
+    replica:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ENC(V/2TFZGXJHrabvQo+mIp9LrP3dGMzdCSuaf9LsJVt0yOzvIyC+ndsMBt2AvvhaCF)
+      username: ENC(nMwtinItmDzyc00a3SmltA==)
+      password: ENC(zo1PkiP39isPi0iRmU5hgkdjpsgmxSYY)
   data:
     redis:
       host: ENC(X5l3B3IOUY0jRMkCuayh2gqCPCD6mIf9)
@@ -50,10 +62,16 @@ spring:
     activate:
       on-profile: prod2
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(bYq1JS4dQAYXjHmn1mDlSPFuiH6jgcX6G7bTFiNTttfKZmfdx+Wz7CtWhZSvkA+7zzN/cWLJxb+VNJLBHYvNLr2Tgc2f5lF5)
-    username: ENC(v1Qf/pZcdMx6bZ2sth8h2A==)
-    password: ENC(YEslivkCss7owXDEzcufYjDhOpGmh12f)
+    source:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ENC(bYq1JS4dQAYXjHmn1mDlSPFuiH6jgcX6G7bTFiNTttfKZmfdx+Wz7CtWhZSvkA+7zzN/cWLJxb+VNJLBHYvNLr2Tgc2f5lF5)
+      username: ENC(v1Qf/pZcdMx6bZ2sth8h2A==)
+      password: ENC(YEslivkCss7owXDEzcufYjDhOpGmh12f)
+    replica:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      jdbc-url: ENC(V/2TFZGXJHrabvQo+mIp9LrP3dGMzdCSuaf9LsJVt0yOzvIyC+ndsMBt2AvvhaCF)
+      username: ENC(nMwtinItmDzyc00a3SmltA==)
+      password: ENC(zo1PkiP39isPi0iRmU5hgkdjpsgmxSYY)
   data:
     redis:
       host: ENC(X5l3B3IOUY0jRMkCuayh2gqCPCD6mIf9)


### PR DESCRIPTION
### 주요 변경사항

- 소스 서버와 레플리카 서버를 통해서 읽기 작업을 분산시켜 성능을 향상시킬 수 있도록 구현했습니다.
- LazyConnectionDataSourceProxy를 사용하여 실제 커넥션이 필요한 시점에 커넥션을 점유하도록 지연시켜 소스 DataSource와 레플리카 DataSource를 결정할 수 있도록 구현했습니다.

### 관련 이슈

- https://github.com/f-lab-edu/i-dol-u/issues/41