### PR TITLE
[#44] 주문 상세 조회하기

### DIFF
--- a/src/main/java/com/flab/idolu/domain/order/controller/OrderController.java
+++ b/src/main/java/com/flab/idolu/domain/order/controller/OrderController.java
@@ -4,6 +4,7 @@ import static com.flab.idolu.global.common.ResponseMessage.Status.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,6 +50,16 @@ public class OrderController {
 		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)
 			.result(orderService.findByMemberId(memberId, size, offset))
+			.build());
+	}
+
+	@MemberLoginCheck
+	@GetMapping("/{id}")
+	public ResponseEntity<ResponseMessage> selectOrder(@PathVariable Long id, @SessionMemberId Long memberId) {
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
+			.result(orderService.findById(id, memberId))
 			.build());
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/order/dto/response/OrderInfoResponse.java
+++ b/src/main/java/com/flab/idolu/domain/order/dto/response/OrderInfoResponse.java
@@ -1,0 +1,37 @@
+package com.flab.idolu.domain.order.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.flab.idolu.domain.order.entity.OrderStatus;
+import com.flab.idolu.domain.payment.entity.PaymentStatus;
+import com.flab.idolu.domain.payment.entity.PaymentType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderInfoResponse {
+
+	private Long id;
+	private Long memberId;
+	private String memberName;
+	private String recipient;
+	private String zipCode;
+	private String address1;
+	private String address2;
+	private String phone;
+	private OrderStatus orderStatus;
+	private BigDecimal totalPrice;
+	private int totalQuantity;
+	private LocalDateTime createdAt;
+	private PaymentType paymentType;
+	private PaymentStatus paymentStatus;
+	private List<OrderProductDto> orderProductList;
+}

--- a/src/main/java/com/flab/idolu/domain/order/dto/response/OrderProductDto.java
+++ b/src/main/java/com/flab/idolu/domain/order/dto/response/OrderProductDto.java
@@ -1,0 +1,21 @@
+package com.flab.idolu.domain.order.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderProductDto {
+
+	private Long productId;
+	private String name;
+	private BigDecimal price;
+	private Integer quantity;
+	private String imageUrl;
+}

--- a/src/main/java/com/flab/idolu/domain/order/exception/InvalidOrderOwnerException.java
+++ b/src/main/java/com/flab/idolu/domain/order/exception/InvalidOrderOwnerException.java
@@ -1,0 +1,8 @@
+package com.flab.idolu.domain.order.exception;
+
+public class InvalidOrderOwnerException extends RuntimeException {
+
+	public InvalidOrderOwnerException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/flab/idolu/domain/order/repository/OrderRepository.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
+import com.flab.idolu.domain.order.dto.response.OrderInfoResponse;
 import com.flab.idolu.domain.order.dto.response.OrderListResponse;
 import com.flab.idolu.domain.order.entity.Order;
 import com.flab.idolu.domain.order.entity.OrderProduct;
@@ -22,4 +23,6 @@ public interface OrderRepository {
 		@Param("memberId") Long memberId,
 		@Param("size") int size,
 		@Param("offset") int offset);
+
+	OrderInfoResponse findById(Long id);
 }

--- a/src/main/java/com/flab/idolu/domain/order/service/OrderService.java
+++ b/src/main/java/com/flab/idolu/domain/order/service/OrderService.java
@@ -10,9 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.flab.idolu.domain.order.dto.request.OrderRequest;
+import com.flab.idolu.domain.order.dto.response.OrderInfoResponse;
 import com.flab.idolu.domain.order.dto.response.OrderListResponse;
 import com.flab.idolu.domain.order.entity.Order;
 import com.flab.idolu.domain.order.entity.OrderProduct;
+import com.flab.idolu.domain.order.exception.InvalidOrderOwnerException;
 import com.flab.idolu.domain.order.repository.OrderRepository;
 import com.flab.idolu.domain.payment.entity.PaymentType;
 import com.flab.idolu.domain.payment.service.PaymentService;
@@ -45,6 +47,17 @@ public class OrderService {
 	public List<OrderListResponse> findByMemberId(Long memberId, int size, int offset) {
 
 		return orderRepository.findByMemberId(memberId, size, size * offset);
+	}
+
+	@Transactional(readOnly = true)
+	public OrderInfoResponse findById(Long id, Long memberId) {
+		OrderInfoResponse orderInfoResponse = orderRepository.findById(id);
+
+		if (!orderInfoResponse.getMemberId().equals(memberId)) {
+			throw new InvalidOrderOwnerException("본인이 구매하지 않은 상품은 조회할 수 없습니다.");
+		}
+
+		return orderInfoResponse;
 	}
 
 	private void validateOrderRequest(OrderRequest orderRequest) {

--- a/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
+++ b/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
@@ -12,6 +12,7 @@ import com.flab.idolu.domain.member.exception.EmailDuplicateException;
 import com.flab.idolu.domain.member.exception.MemberNotFoundException;
 import com.flab.idolu.domain.member.exception.PasswordNotMatchException;
 import com.flab.idolu.domain.member.exception.UnauthorizedMemberException;
+import com.flab.idolu.domain.order.exception.InvalidOrderOwnerException;
 import com.flab.idolu.domain.product.exception.InsufficientStockException;
 import com.flab.idolu.domain.product.exception.ProductNotFoundException;
 import com.flab.idolu.global.common.ResponseMessage;
@@ -96,6 +97,16 @@ public class ExceptionAdvice {
 	protected ResponseEntity<ResponseMessage> insufficientStockException(InsufficientStockException exception) {
 		log.info("AddressNotFoundException: {}", exception.getMessage());
 		return ResponseEntity.status(BAD_REQUEST)
+			.body(ResponseMessage.builder()
+				.status(FAIL)
+				.message(exception.getMessage())
+				.build());
+	}
+
+	@ExceptionHandler(InvalidOrderOwnerException.class)
+	protected ResponseEntity<ResponseMessage> invalidOrderOwnerException(InvalidOrderOwnerException exception) {
+		log.info("InvalidOrderOwnerException: {}", exception.getMessage());
+		return ResponseEntity.status(FORBIDDEN)
 			.body(ResponseMessage.builder()
 				.status(FAIL)
 				.message(exception.getMessage())

--- a/src/main/resources/mybatis/mapper/order/OrderMap.xml
+++ b/src/main/resources/mybatis/mapper/order/OrderMap.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.idolu.domain.order.repository.OrderRepository">
+    <resultMap id="orderAndPaymentAndOrderProducts" type="OrderInfoResponse">
+        <id column="id" property="id" />
+        <result column="member_id" property="memberId" />
+        <result column="member_name" property="memberName" />
+        <result column="recipient" property="recipient" />
+        <result column="zip_code" property="zipCode" />
+        <result column="address1" property="address1" />
+        <result column="address2" property="address2" />
+        <result column="phone" property="phone" />
+        <result column="order_status" property="orderStatus" />
+        <result column="total_price" property="totalPrice" />
+        <result column="total_quantity" property="totalQuantity" />
+        <result column="created_at" property="createdAt" />
+        <result column="payment_type" property="paymentType" />
+        <result column="payment_status" property="paymentStatus" />
+        <collection property="orderProductList" ofType="OrderProductDto">
+            <id column="product_id" property="productId" />
+            <result column="price" property="price" />
+            <result column="quantity" property="quantity" />
+            <result column="product_name" property="name" />
+            <result column="image_url" property="imageUrl" />
+        </collection>
+    </resultMap>
+</mapper>

--- a/src/main/resources/mybatis/mapper/order/OrderMapper.xml
+++ b/src/main/resources/mybatis/mapper/order/OrderMapper.xml
@@ -26,8 +26,8 @@
                o.order_status
         FROM orders o
                  JOIN (SELECT op.order_id,
-                              MAX(op.product_id)   as product_id,
-                              COUNT(op.product_id) as product_count
+                              MAX(op.product_id)   AS product_id,
+                              COUNT(op.product_id) AS product_count
                        FROM order_product op
                        GROUP BY op.order_id) opt ON opt.order_id = o.id
                  JOIN product p ON p.id = opt.product_id
@@ -35,5 +35,34 @@
         ORDER BY o.id DESC
         LIMIT #{size}
         OFFSET #{offset}
+    </select>
+
+    <select id="findById" resultMap="orderAndPaymentAndOrderProducts">
+        SELECT
+            o.id,
+            o.member_id,
+            m.name AS member_name,
+            o.recipient,
+            o.zip_code,
+            o.address1,
+            o.address2,
+            o.phone,
+            o.order_status,
+            o.total_price,
+            o.total_quantity,
+            o.created_at,
+            p.payment_type,
+            p.payment_status,
+            op.product_id,
+            op.price,
+            op.quantity,
+            pr.name AS product_name,
+            pr.image_url
+        FROM orders o
+                 JOIN payment p ON p.order_id = o.id
+                 JOIN member m ON m.id = o.member_id
+                 JOIN order_product op ON op.order_id = o.id
+                 JOIN product pr ON pr.id = op.product_id
+        WHERE o.id = #{id};
     </select>
 </mapper>

--- a/src/test/groovy/com/flab/idolu/domain/fixture/OrderFixture.java
+++ b/src/test/groovy/com/flab/idolu/domain/fixture/OrderFixture.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.flab.idolu.domain.order.dto.request.OrderLineItemDto;
 import com.flab.idolu.domain.order.dto.request.OrderRequest;
+import com.flab.idolu.domain.order.dto.response.OrderInfoResponse;
 
 public class OrderFixture {
 
@@ -108,5 +109,16 @@ public class OrderFixture {
 		.address2("상세 주소")
 		.orderLineItems(List.of(DEFAULT_ORDER_LINE_ITEM))
 		.paymentType("PAY")
+		.build();
+
+	public static final OrderInfoResponse VALID_ORDER_INFO_RESPONSE = OrderInfoResponse.builder()
+		.id(1L)
+		.memberId(1L)
+		.memberName("oneny")
+		.build();
+
+	public static final OrderInfoResponse INVALID_MEMBER_ID_RESPONSE = OrderInfoResponse.builder()
+		.id(1L)
+		.memberId(2L)
 		.build();
 }

--- a/src/test/groovy/com/flab/idolu/domain/order/service/OrderServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/order/service/OrderServiceTest.groovy
@@ -1,5 +1,7 @@
 package com.flab.idolu.domain.order.service
 
+import com.flab.idolu.domain.order.dto.response.OrderInfoResponse
+import com.flab.idolu.domain.order.exception.InvalidOrderOwnerException
 import com.flab.idolu.domain.order.repository.OrderRepository
 import com.flab.idolu.domain.payment.repository.PaymentRepository
 import com.flab.idolu.domain.payment.service.PaymentService
@@ -63,5 +65,30 @@ class OrderServiceTest extends Specification {
 
         then:
         1 * orderRepository.findByMemberId(1L, 1, 1)
+    }
+
+    def "주문 상세 조회 실패 테스트"() {
+        given:
+        orderRepository.findById(1L) >> INVALID_MEMBER_ID_RESPONSE
+
+        when:
+        orderService.findById(1L, 1L)
+
+        then:
+        def exception = thrown(InvalidOrderOwnerException)
+        exception.getMessage() == "본인이 구매하지 않은 상품은 조회할 수 없습니다."
+    }
+
+    def "주문 상세 조회 성공 테스트"() {
+        given:
+        orderRepository.findById(1L) >> VALID_ORDER_INFO_RESPONSE
+
+        when:
+        def orderInfoResponse = orderService.findById(1L, 1L)
+
+        then:
+        orderInfoResponse.id == 1L
+        orderInfoResponse.memberId == 1L
+        orderInfoResponse.memberName == "oneny"
     }
 }


### PR DESCRIPTION
### 주요 변경사항

![image](https://github.com/f-lab-edu/i-dol-u/assets/97153666/5950440c-aaa0-4030-aa22-06ba5b0ae0f0)

- 위 프로토타입에 따라 결과를 반환하도록 구현했습니다.
- RTT를 고려하여 MyBatis의 resultMap을 사용하여 1번의 요청으로 필요한 결과를 반환하도록 구현했습니다.
- 본인이 구매하지 않은 주문을 조회하려는 경우 InvalidOrderOwnerException 예외가 발생하도록 구현했습니다.

### 관련 이슈

- https://github.com/f-lab-edu/i-dol-u/issues/44