### PR TITLE
[#45] 카트 상품 담기

### DIFF
--- a/src/main/java/com/flab/idolu/domain/cart/controller/CartController.java
+++ b/src/main/java/com/flab/idolu/domain/cart/controller/CartController.java
@@ -1,0 +1,38 @@
+package com.flab.idolu.domain.cart.controller;
+
+import static com.flab.idolu.global.common.ResponseMessage.Status.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.service.CartService;
+import com.flab.idolu.global.annotation.MemberLoginCheck;
+import com.flab.idolu.global.annotation.SessionMemberId;
+import com.flab.idolu.global.common.ResponseMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/carts")
+public class CartController {
+
+	private final CartService cartService;
+
+	@PostMapping
+	@MemberLoginCheck
+	public ResponseEntity<ResponseMessage> createCartProduct(
+		@RequestBody CartProductRequest cartProductRequest,
+		@SessionMemberId Long memberId) {
+		
+		cartService.insertCart(cartProductRequest, memberId);
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
+			.build());
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/cart/dto/request/CartProductRequest.java
+++ b/src/main/java/com/flab/idolu/domain/cart/dto/request/CartProductRequest.java
@@ -1,0 +1,22 @@
+package com.flab.idolu.domain.cart.dto.request;
+
+import com.flab.idolu.domain.cart.entity.Cart;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CartProductRequest {
+
+	private Long productId;
+	private Integer quantity;
+
+	public Cart toEntity(Long memberId) {
+		return Cart.builder()
+			.productId(productId)
+			.memberId(memberId)
+			.quantity(quantity)
+			.build();
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/cart/entity/Cart.java
+++ b/src/main/java/com/flab/idolu/domain/cart/entity/Cart.java
@@ -1,0 +1,25 @@
+package com.flab.idolu.domain.cart.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class Cart {
+
+	private Long id;
+	private Long productId;
+	private Long memberId;
+	private Integer quantity;
+	private boolean isDeleted;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/flab/idolu/domain/cart/entity/Cart.java
+++ b/src/main/java/com/flab/idolu/domain/cart/entity/Cart.java
@@ -22,4 +22,9 @@ public class Cart {
 	private boolean isDeleted;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
+
+	public Cart addQuantity(Integer quantity) {
+		this.quantity += quantity;
+		return this;
+	}
 }

--- a/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
@@ -1,0 +1,13 @@
+package com.flab.idolu.domain.cart.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+import com.flab.idolu.domain.cart.entity.Cart;
+
+@Mapper
+@Repository
+public interface CartRepository {
+
+	void insertCart(Cart cart);
+}

--- a/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
@@ -1,6 +1,9 @@
 package com.flab.idolu.domain.cart.repository;
 
+import java.util.Optional;
+
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import com.flab.idolu.domain.cart.entity.Cart;
@@ -10,4 +13,6 @@ import com.flab.idolu.domain.cart.entity.Cart;
 public interface CartRepository {
 
 	void insertCart(Cart cart);
+
+	Optional<Cart> findByProductIdAndMemberId(@Param("productId") Long productId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
@@ -15,4 +15,6 @@ public interface CartRepository {
 	void insertCart(Cart cart);
 
 	Optional<Cart> findByProductIdAndMemberId(@Param("productId") Long productId, @Param("memberId") Long memberId);
+
+	void updateCartQuantity(Cart cart);
 }

--- a/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
+++ b/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
@@ -1,0 +1,36 @@
+package com.flab.idolu.domain.cart.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.repository.CartRepository;
+import com.flab.idolu.domain.product.exception.ProductNotFoundException;
+import com.flab.idolu.domain.product.repository.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+	private final CartRepository cartRepository;
+	private final ProductRepository productRepository;
+
+	@Transactional
+	public void insertCart(CartProductRequest cartProductRequest, Long memberId) {
+		validateCartProduct(cartProductRequest);
+
+		productRepository.findById(cartProductRequest.getProductId())
+			.orElseThrow(() -> new ProductNotFoundException("상품이 없습니다."));
+
+		cartRepository.insertCart(cartProductRequest.toEntity(memberId));
+	}
+
+	private void validateCartProduct(CartProductRequest cartProductRequest) {
+		Assert.notNull(cartProductRequest.getProductId(), "상품 id를 입력해주세요.");
+		Assert.notNull(cartProductRequest.getQuantity(), "수량을 입력해주세요.");
+		Assert.isTrue(cartProductRequest.getQuantity().compareTo(0) > 0, "수량이 0보다 커야 합니다.");
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
+++ b/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
@@ -1,10 +1,13 @@
 package com.flab.idolu.domain.cart.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.entity.Cart;
 import com.flab.idolu.domain.cart.repository.CartRepository;
 import com.flab.idolu.domain.product.exception.ProductNotFoundException;
 import com.flab.idolu.domain.product.repository.ProductRepository;
@@ -25,7 +28,14 @@ public class CartService {
 		productRepository.findById(cartProductRequest.getProductId())
 			.orElseThrow(() -> new ProductNotFoundException("상품이 없습니다."));
 
-		cartRepository.insertCart(cartProductRequest.toEntity(memberId));
+		Cart requestCart = cartProductRequest.toEntity(memberId);
+		Optional<Cart> optionalCart = cartRepository.findByProductIdAndMemberId(requestCart.getProductId(), memberId);
+
+		if (optionalCart.isPresent()) {
+			cartRepository.updateCartQuantity(optionalCart.get().addQuantity(requestCart.getQuantity()));
+		} else {
+			cartRepository.insertCart(cartProductRequest.toEntity(memberId));
+		}
 	}
 
 	private void validateCartProduct(CartProductRequest cartProductRequest) {

--- a/src/main/resources/mybatis/mapper/cart/CartMapper.xml
+++ b/src/main/resources/mybatis/mapper/cart/CartMapper.xml
@@ -12,4 +12,11 @@
         FROM cart
         WHERE product_id = #{productId} AND member_id = #{memberId}
     </select>
+
+    <update id="updateCartQuantity">
+        UPDATE cart
+        SET quantity = #{quantity},
+            updated_at = NOW()
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mybatis/mapper/cart/CartMapper.xml
+++ b/src/main/resources/mybatis/mapper/cart/CartMapper.xml
@@ -6,4 +6,10 @@
         INSERT INTO cart (product_id, member_id, quantity, is_deleted, created_at, updated_at)
         VALUES (#{productId}, #{memberId}, #{quantity}, false, NOW(), NOW())
     </insert>
+
+    <select id="findByProductIdAndMemberId" resultType="Cart">
+        SELECT *
+        FROM cart
+        WHERE product_id = #{productId} AND member_id = #{memberId}
+    </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/cart/CartMapper.xml
+++ b/src/main/resources/mybatis/mapper/cart/CartMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.flab.idolu.domain.cart.repository.CartRepository">
+
+    <insert id="insertCart" keyProperty="id" useGeneratedKeys="true">
+        INSERT INTO cart (product_id, member_id, quantity, is_deleted, created_at, updated_at)
+        VALUES (#{productId}, #{memberId}, #{quantity}, false, NOW(), NOW())
+    </insert>
+</mapper>

--- a/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
@@ -1,0 +1,58 @@
+package com.flab.idolu.domain.cart.service
+
+import com.flab.idolu.domain.cart.repository.CartRepository
+import com.flab.idolu.domain.product.exception.ProductNotFoundException
+import com.flab.idolu.domain.product.repository.ProductRepository
+import spock.lang.Specification
+
+import static com.flab.idolu.domain.fixture.CartFixture.*
+import static com.flab.idolu.domain.fixture.ProductFixture.DEFAULT_PRODUCT
+
+class CartServiceTest extends Specification {
+
+    CartService cartService
+    CartRepository cartRepository = Mock()
+    ProductRepository productRepository = Mock()
+
+    def setup() {
+        cartService = new CartService(cartRepository, productRepository)
+    }
+
+    def "카트 상품 등록 실패 테스트: #exceptionMessage"() {
+        when:
+        cartService.insertCart(cart, 1L)
+
+        then:
+        def exception = thrown(IllegalArgumentException)
+        exception.message == exceptionMessage
+
+        where:
+        cart                       | exceptionMessage
+        INVALID_PRODUCT_ID_CART    | "상품 id를 입력해주세요."
+        INVALID_QUANTITY_CART      | "수량을 입력해주세요."
+        INSUFFICIENT_QUANTITY_CART | "수량이 0보다 커야 합니다."
+    }
+
+    def "카트 상품 등록 실패 테스트: 상품 없음"() {
+        given:
+        productRepository.findById(1L) >> Optional.empty()
+
+        when:
+        cartService.insertCart(DEFAULT_CART, 1L)
+
+        then:
+        def exception = thrown(ProductNotFoundException)
+        exception.message == "상품이 없습니다."
+    }
+
+    def "카트 상품 등록 성공 테스트"() {
+        given:
+        productRepository.findById(1L) >> Optional.of(DEFAULT_PRODUCT)
+
+        when:
+        cartService.insertCart(DEFAULT_CART, 1L)
+
+        then:
+        1 * cartRepository.insertCart(_)
+    }
+}

--- a/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
@@ -1,5 +1,6 @@
 package com.flab.idolu.domain.cart.service
 
+import com.flab.idolu.domain.cart.entity.Cart
 import com.flab.idolu.domain.cart.repository.CartRepository
 import com.flab.idolu.domain.product.exception.ProductNotFoundException
 import com.flab.idolu.domain.product.repository.ProductRepository
@@ -38,19 +39,32 @@ class CartServiceTest extends Specification {
         productRepository.findById(1L) >> Optional.empty()
 
         when:
-        cartService.insertCart(DEFAULT_CART, 1L)
+        cartService.insertCart(DEFAULT_CART_PRODUCT_REQUEST, 1L)
 
         then:
         def exception = thrown(ProductNotFoundException)
         exception.message == "상품이 없습니다."
     }
 
-    def "카트 상품 등록 성공 테스트"() {
+    def "카트 상품 등록 성공 테스트: 카트 상품 존재"() {
         given:
         productRepository.findById(1L) >> Optional.of(DEFAULT_PRODUCT)
+        cartRepository.findByProductIdAndMemberId(1L, 1L) >> Optional.of(DEFAULT_CART)
 
         when:
-        cartService.insertCart(DEFAULT_CART, 1L)
+        cartService.insertCart(DEFAULT_CART_PRODUCT_REQUEST, 1L)
+
+        then:
+        1 * cartRepository.updateCartQuantity(_)
+    }
+
+    def "카트 상품 등록 성공 테스트: 카트에 상품 존재하지 않음"() {
+        given:
+        productRepository.findById(1L) >> Optional.of(DEFAULT_PRODUCT)
+        cartRepository.findByProductIdAndMemberId(1L, 1L) >> Optional.empty()
+
+        when:
+        cartService.insertCart(DEFAULT_CART_PRODUCT_REQUEST, 1L)
 
         then:
         1 * cartRepository.insertCart(_)

--- a/src/test/groovy/com/flab/idolu/domain/fixture/CartFixture.java
+++ b/src/test/groovy/com/flab/idolu/domain/fixture/CartFixture.java
@@ -1,0 +1,24 @@
+package com.flab.idolu.domain.fixture;
+
+import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+
+public class CartFixture {
+
+	public static final CartProductRequest INVALID_PRODUCT_ID_CART = CartProductRequest.builder()
+		.quantity(10)
+		.build();
+
+	public static final CartProductRequest INVALID_QUANTITY_CART = CartProductRequest.builder()
+		.productId(1L)
+		.build();
+
+	public static final CartProductRequest INSUFFICIENT_QUANTITY_CART = CartProductRequest.builder()
+		.productId(1L)
+		.quantity(0)
+		.build();
+
+	public static final CartProductRequest DEFAULT_CART = CartProductRequest.builder()
+		.productId(1L)
+		.quantity(1)
+		.build();
+}

--- a/src/test/groovy/com/flab/idolu/domain/fixture/CartFixture.java
+++ b/src/test/groovy/com/flab/idolu/domain/fixture/CartFixture.java
@@ -1,6 +1,7 @@
 package com.flab.idolu.domain.fixture;
 
 import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.entity.Cart;
 
 public class CartFixture {
 
@@ -17,8 +18,15 @@ public class CartFixture {
 		.quantity(0)
 		.build();
 
-	public static final CartProductRequest DEFAULT_CART = CartProductRequest.builder()
+	public static final CartProductRequest DEFAULT_CART_PRODUCT_REQUEST = CartProductRequest.builder()
 		.productId(1L)
+		.quantity(1)
+		.build();
+
+	public static final Cart DEFAULT_CART = Cart.builder()
+		.id(1L)
+		.productId(1L)
+		.memberId(1L)
 		.quantity(1)
 		.build();
 }


### PR DESCRIPTION
### 주요 변경사항

- 카트 상품 담기 기능을 구현했습니다.
  - 상품을 조회하고 없는 상품인 경우에는 ProductNotFoundException이 발생하도록 구현했습니다.
  - 카트 상품이 이미 존재하는 경우에는 수량을 추가하도록 구현했습니다.
  - 카트 상품이 존재하지 않는 경우에는 카트 상품을 등록하도록 구현했습니다.

### 관련 이슈

- https://github.com/f-lab-edu/i-dol-u/issues/45