### PR TITLE
[#47] 카트 수량 업데이트/삭제하기

### DIFF
--- a/src/main/java/com/flab/idolu/domain/cart/controller/CartController.java
+++ b/src/main/java/com/flab/idolu/domain/cart/controller/CartController.java
@@ -4,12 +4,16 @@ import static com.flab.idolu.global.common.ResponseMessage.Status.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.dto.request.ModifyCartQuantityRequest;
 import com.flab.idolu.domain.cart.service.CartService;
 import com.flab.idolu.global.annotation.MemberLoginCheck;
 import com.flab.idolu.global.annotation.SessionMemberId;
@@ -44,6 +48,20 @@ public class CartController {
 		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)
 			.result(cartService.findByMemberId(memberId))
+			.build());
+	}
+
+	@MemberLoginCheck
+	@PutMapping("/{cartId}")
+	public ResponseEntity<ResponseMessage> updateCartQuantity(
+		@SessionMemberId Long memberId,
+		@PathVariable Long cartId,
+		@RequestBody ModifyCartQuantityRequest modifyCartQuantityRequest
+		) {
+		cartService.updateCartQuantity(cartId, modifyCartQuantityRequest, memberId);
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
 			.build());
 	}
 }

--- a/src/main/java/com/flab/idolu/domain/cart/controller/CartController.java
+++ b/src/main/java/com/flab/idolu/domain/cart/controller/CartController.java
@@ -4,12 +4,12 @@ import static com.flab.idolu.global.common.ResponseMessage.Status.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
@@ -33,7 +33,7 @@ public class CartController {
 	public ResponseEntity<ResponseMessage> createCartProduct(
 		@RequestBody CartProductRequest cartProductRequest,
 		@SessionMemberId Long memberId) {
-		
+
 		cartService.insertCart(cartProductRequest, memberId);
 
 		return ResponseEntity.ok(ResponseMessage.builder()
@@ -57,8 +57,21 @@ public class CartController {
 		@SessionMemberId Long memberId,
 		@PathVariable Long cartId,
 		@RequestBody ModifyCartQuantityRequest modifyCartQuantityRequest
-		) {
+	) {
 		cartService.updateCartQuantity(cartId, modifyCartQuantityRequest, memberId);
+
+		return ResponseEntity.ok(ResponseMessage.builder()
+			.status(SUCCESS)
+			.build());
+	}
+
+	@MemberLoginCheck
+	@PatchMapping("/{cartId}/delete")
+	public ResponseEntity<ResponseMessage> updateCartQuantity(
+		@SessionMemberId Long memberId,
+		@PathVariable Long cartId
+	) {
+		cartService.updateDeletedById(cartId, memberId);
 
 		return ResponseEntity.ok(ResponseMessage.builder()
 			.status(SUCCESS)

--- a/src/main/java/com/flab/idolu/domain/cart/dto/request/ModifyCartQuantityRequest.java
+++ b/src/main/java/com/flab/idolu/domain/cart/dto/request/ModifyCartQuantityRequest.java
@@ -1,0 +1,10 @@
+package com.flab.idolu.domain.cart.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+public record ModifyCartQuantityRequest(
+	Integer quantity
+) {
+}

--- a/src/main/java/com/flab/idolu/domain/cart/entity/Cart.java
+++ b/src/main/java/com/flab/idolu/domain/cart/entity/Cart.java
@@ -27,4 +27,8 @@ public class Cart {
 		this.quantity += quantity;
 		return this;
 	}
+
+	public void changQuantity(Integer quantity) {
+		this.quantity = quantity;
+	}
 }

--- a/src/main/java/com/flab/idolu/domain/cart/exception/CartNotFoundException.java
+++ b/src/main/java/com/flab/idolu/domain/cart/exception/CartNotFoundException.java
@@ -1,0 +1,8 @@
+package com.flab.idolu.domain.cart.exception;
+
+public class CartNotFoundException extends RuntimeException {
+
+	public CartNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
@@ -21,4 +21,6 @@ public interface CartRepository {
 	void updateCartQuantity(Cart cart);
 
 	List<CartProductResponse> findByMemberId(Long memberId);
+
+	Optional<Cart> findById(Long id);
 }

--- a/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/flab/idolu/domain/cart/repository/CartRepository.java
@@ -23,4 +23,6 @@ public interface CartRepository {
 	List<CartProductResponse> findByMemberId(Long memberId);
 
 	Optional<Cart> findById(Long id);
+
+	void updateDeletedById(Long id);
 }

--- a/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
+++ b/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
@@ -62,6 +62,17 @@ public class CartService {
 		cartRepository.updateCartQuantity(cart);
 	}
 
+	@Transactional
+	public void updateDeletedById(Long cartId, Long memberId) {
+		Cart cart = cartRepository.findById(cartId)
+			.orElseThrow(() -> new CartNotFoundException("존재하는 카트 상품이 없습니다."));
+		if (!cart.getMemberId().equals(memberId)) {
+			throw new UnauthorizedMemberException("본인의 카트 상품만 수량 수정이 가능합니다.");
+		}
+
+		cartRepository.updateDeletedById(cartId);
+	}
+
 	private void validateCartQuantityRequest(ModifyCartQuantityRequest modifyCartQuantityRequest) {
 		Assert.notNull(modifyCartQuantityRequest.quantity(), "수량을 입력해주세요.");
 		Assert.isTrue(modifyCartQuantityRequest.quantity().compareTo(0) > 0, "수량이 0보다 커야 합니다.");

--- a/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
+++ b/src/main/java/com/flab/idolu/domain/cart/service/CartService.java
@@ -8,9 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.dto.request.ModifyCartQuantityRequest;
 import com.flab.idolu.domain.cart.dto.response.CartProductResponse;
 import com.flab.idolu.domain.cart.entity.Cart;
+import com.flab.idolu.domain.cart.exception.CartNotFoundException;
 import com.flab.idolu.domain.cart.repository.CartRepository;
+import com.flab.idolu.domain.member.exception.UnauthorizedMemberException;
 import com.flab.idolu.domain.product.exception.ProductNotFoundException;
 import com.flab.idolu.domain.product.repository.ProductRepository;
 
@@ -43,6 +46,25 @@ public class CartService {
 	@Transactional(readOnly = true)
 	public List<CartProductResponse> findByMemberId(Long memberId) {
 		return cartRepository.findByMemberId(memberId);
+	}
+
+	@Transactional
+	public void updateCartQuantity(Long cartId, ModifyCartQuantityRequest modifyCartQuantityRequest, Long memberId) {
+		validateCartQuantityRequest(modifyCartQuantityRequest);
+
+		Cart cart = cartRepository.findById(cartId)
+			.orElseThrow(() -> new CartNotFoundException("존재하는 카트 상품이 없습니다."));
+		if (!cart.getMemberId().equals(memberId)) {
+			throw new UnauthorizedMemberException("본인의 카트 상품만 수량 수정이 가능합니다.");
+		}
+
+		cart.changQuantity(modifyCartQuantityRequest.quantity());
+		cartRepository.updateCartQuantity(cart);
+	}
+
+	private void validateCartQuantityRequest(ModifyCartQuantityRequest modifyCartQuantityRequest) {
+		Assert.notNull(modifyCartQuantityRequest.quantity(), "수량을 입력해주세요.");
+		Assert.isTrue(modifyCartQuantityRequest.quantity().compareTo(0) > 0, "수량이 0보다 커야 합니다.");
 	}
 
 	private void validateCartProduct(CartProductRequest cartProductRequest) {

--- a/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
+++ b/src/main/java/com/flab/idolu/global/advice/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.flab.idolu.domain.address.exception.AddressNotFoundException;
+import com.flab.idolu.domain.cart.exception.CartNotFoundException;
 import com.flab.idolu.domain.member.exception.EmailDuplicateException;
 import com.flab.idolu.domain.member.exception.MemberNotFoundException;
 import com.flab.idolu.domain.member.exception.PasswordNotMatchException;
@@ -106,6 +107,16 @@ public class ExceptionAdvice {
 	@ExceptionHandler(InvalidOrderOwnerException.class)
 	protected ResponseEntity<ResponseMessage> invalidOrderOwnerException(InvalidOrderOwnerException exception) {
 		log.info("InvalidOrderOwnerException: {}", exception.getMessage());
+		return ResponseEntity.status(FORBIDDEN)
+			.body(ResponseMessage.builder()
+				.status(FAIL)
+				.message(exception.getMessage())
+				.build());
+	}
+
+	@ExceptionHandler(CartNotFoundException.class)
+	protected ResponseEntity<ResponseMessage> cartNotFoundException(CartNotFoundException exception) {
+		log.info("CartNotFoundException: {}", exception.getMessage());
 		return ResponseEntity.status(FORBIDDEN)
 			.body(ResponseMessage.builder()
 				.status(FAIL)

--- a/src/main/resources/mybatis/mapper/cart/CartMapper.xml
+++ b/src/main/resources/mybatis/mapper/cart/CartMapper.xml
@@ -30,5 +30,12 @@
                p.image_url
         FROM cart c
                  JOIN product p ON p.id = c.product_id
+        WHERE member_id = #{member_id}
+    </select>
+
+    <select id="findById">
+        SELECT *
+        FROM cart
+        WHERE id = #{id}
     </select>
 </mapper>

--- a/src/main/resources/mybatis/mapper/cart/CartMapper.xml
+++ b/src/main/resources/mybatis/mapper/cart/CartMapper.xml
@@ -12,6 +12,7 @@
         FROM cart
         WHERE product_id = #{productId}
           AND member_id = #{memberId}
+          AND is_deleted = false
     </select>
 
     <update id="updateCartQuantity">
@@ -30,12 +31,21 @@
                p.image_url
         FROM cart c
                  JOIN product p ON p.id = c.product_id
-        WHERE member_id = #{member_id}
+        WHERE member_id = #{memberId}
+          AND c.is_deleted = false
     </select>
 
     <select id="findById">
         SELECT *
         FROM cart
         WHERE id = #{id}
+          AND is_deleted = false
     </select>
+
+    <update id="updateDeletedById">
+        UPDATE cart
+        SET is_deleted = true,
+            updated_at = NOW()
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
@@ -1,7 +1,9 @@
 package com.flab.idolu.domain.cart.service
 
 import com.flab.idolu.domain.cart.entity.Cart
+import com.flab.idolu.domain.cart.exception.CartNotFoundException
 import com.flab.idolu.domain.cart.repository.CartRepository
+import com.flab.idolu.domain.member.exception.UnauthorizedMemberException
 import com.flab.idolu.domain.product.exception.ProductNotFoundException
 import com.flab.idolu.domain.product.repository.ProductRepository
 import spock.lang.Specification
@@ -80,5 +82,55 @@ class CartServiceTest extends Specification {
         then:
         cartProduct.size() == 1
         cartProduct.get(0).id == 1L
+    }
+
+    def "카트 수량 수정 실패 테스트: #exceptionMessage"() {
+        when:
+        cartService.updateCartQuantity(1L, cartQuantityRequest, 1L)
+
+        then:
+        def exception = thrown(IllegalArgumentException)
+        exception.message == exceptionMessage
+
+        where:
+        cartQuantityRequest                | exceptionMessage
+        INVALID_QUANTITY_CART_REQUEST      | "수량을 입력해주세요."
+        INSUFFICIENT_QUANTITY_CART_REQUEST | "수량이 0보다 커야 합니다."
+    }
+
+    def "카트 수량 수정 실패 테스트: 카트 상품 없음"() {
+        given:
+        cartRepository.findById(1L) >> Optional.empty()
+
+        when:
+        cartService.updateCartQuantity(1L, DEFAULT_CART_REQUEST, 1L)
+
+        then:
+        def exception = thrown(CartNotFoundException)
+        exception.message == "존재하는 카트 상품이 없습니다."
+    }
+
+    def "카트 수량 수정 실패 테스트: 본인 상품 아님"() {
+        given:
+        cartRepository.findById(1L) >> Optional.of(DEFAULT_CART)
+
+        when:
+        cartService.updateCartQuantity(1L, DEFAULT_CART_REQUEST, 2L)
+
+        then:
+        def exception = thrown(UnauthorizedMemberException)
+        exception.message == "본인의 카트 상품만 수량 수정이 가능합니다."
+    }
+
+    def "카트 수량 수정 성공 테스트"() {
+        given:
+        cartRepository.findById(1L) >> Optional.of(DEFAULT_CART)
+
+        when:
+        cartService.updateCartQuantity(1L, DEFAULT_CART_REQUEST, 1L)
+
+        then:
+        def findCart = cartRepository.findById(1L).get()
+        findCart.quantity == 3
     }
 }

--- a/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
+++ b/src/test/groovy/com/flab/idolu/domain/cart/service/CartServiceTest.groovy
@@ -1,6 +1,6 @@
 package com.flab.idolu.domain.cart.service
 
-import com.flab.idolu.domain.cart.entity.Cart
+
 import com.flab.idolu.domain.cart.exception.CartNotFoundException
 import com.flab.idolu.domain.cart.repository.CartRepository
 import com.flab.idolu.domain.member.exception.UnauthorizedMemberException
@@ -132,5 +132,40 @@ class CartServiceTest extends Specification {
         then:
         def findCart = cartRepository.findById(1L).get()
         findCart.quantity == 3
+    }
+
+    def "카트 삭제 실패 테스트: 상품 없음"() {
+        given:
+        cartRepository.findById(1L) >> Optional.empty()
+
+        when:
+        cartService.updateDeletedById(1L, 1L)
+
+        then:
+        def exception = thrown(CartNotFoundException)
+        exception.message == "존재하는 카트 상품이 없습니다."
+    }
+
+    def "카트 삭제 실패 테스트: 본인 상품 아님"() {
+        given:
+        cartRepository.findById(1L) >> Optional.of(DEFAULT_CART)
+
+        when:
+        cartService.updateDeletedById(1L, 2L)
+
+        then:
+        def exception = thrown(UnauthorizedMemberException)
+        exception.message == "본인의 카트 상품만 수량 수정이 가능합니다."
+    }
+
+    def "카트 삭제 성공 테스트"() {
+        given:
+        cartRepository.findById(1L) >> Optional.of(DEFAULT_CART)
+
+        when:
+        cartService.updateDeletedById(1L, 1L)
+
+        then:
+        1 * cartRepository.updateDeletedById(1L)
     }
 }

--- a/src/test/groovy/com/flab/idolu/domain/fixture/CartFixture.java
+++ b/src/test/groovy/com/flab/idolu/domain/fixture/CartFixture.java
@@ -1,6 +1,7 @@
 package com.flab.idolu.domain.fixture;
 
 import com.flab.idolu.domain.cart.dto.request.CartProductRequest;
+import com.flab.idolu.domain.cart.dto.request.ModifyCartQuantityRequest;
 import com.flab.idolu.domain.cart.dto.response.CartProductResponse;
 import com.flab.idolu.domain.cart.entity.Cart;
 
@@ -37,5 +38,16 @@ public class CartFixture {
 		.name("productA")
 		.imageUrl("url")
 		.quantity(1)
+		.build();
+
+	public static final ModifyCartQuantityRequest INSUFFICIENT_QUANTITY_CART_REQUEST = ModifyCartQuantityRequest.builder()
+		.quantity(0)
+		.build();
+
+	public static final ModifyCartQuantityRequest INVALID_QUANTITY_CART_REQUEST = ModifyCartQuantityRequest.builder()
+		.build();
+
+	public static final ModifyCartQuantityRequest DEFAULT_CART_REQUEST = ModifyCartQuantityRequest.builder()
+		.quantity(3)
 		.build();
 }


### PR DESCRIPTION
### 주요 변경사항

- 카트 상품 수량 업데이트 및 삭제하기 기능을 구현했습니다.
    - 카트 상품이 존재하지 않는 경우에는 CartNotFoundException가 발생하도록 구현했습니다.
    - 본인 상품이 아닌 경우에는 UnauthorizedMemberException가 발생하도록 구현했습니다.

### 관련 이슈

- https://github.com/f-lab-edu/i-dol-u/issues/47